### PR TITLE
Refactor NATS JetStream Pull subscription to use the NATS simplified API

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/PullSubscribeConnectionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/PullSubscribeConnectionTest.java
@@ -83,11 +83,6 @@ public class PullSubscribeConnectionTest {
             }
 
             @Override
-            public Integer rePullAt() {
-                return 50;
-            }
-
-            @Override
             public Integer batchSize() {
                 return 100;
             }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -169,9 +169,9 @@ mp.messaging.incoming.[channel-name].memory-storage,"If set, forces the consumer
 mp.messaging.incoming.[channel-name].back-off,The timing of re-deliveries as a comma-separated list of durations
 mp.messaging.incoming.[channel-name].retry-backoff,The retry backoff in milliseconds for retry publishing messages
 mp.messaging.incoming.[channel-name].pull.batch-size,The size of batch of messages to be pulled in pull mode
-mp.messaging.incoming.[channel-name].pull.re-pull-at,The point in the current batch to tell the server to start the next batch
+mp.messaging.incoming.[channel-name].pull.re-pull-at,The point in the current batch to tell the server to start the next batch. Not used anymore.
 mp.messaging.incoming.[channel-name].pull.max-waiting,The maximum number of waiting pull requests
-mp.messaging.incoming.[channel-name].pull.max-expires,The maximum duration a single pull request will wait for messages to be available to pull
+mp.messaging.incoming.[channel-name].pull.max-expires,The maximum duration a single pull request will wait for messages to be available to pull. NATS require this to be 1000ms or above. Default is 3000ms.
 mp.messaging.incoming.[channel-name].push.ordered,Flag indicating whether this subscription should be ordered
 mp.messaging.incoming.[channel-name].push.deliver-group,The optional deliver group to join
 mp.messaging.incoming.[channel-name].push.flow-control,Enables per-subscription flow control using a sliding-window protocol. This protocol relies on the server and client exchanging messages to regulate when and how many messages are pushed to the client. This one-to-one flow control mechanism works in tandem with the one-to-many flow control imposed by MaxAckPending across all subscriptions bound to a consumer.

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/NatsConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/NatsConfiguration.java
@@ -58,7 +58,7 @@ public interface NatsConfiguration {
 
     /**
      * The maximum number of attempts to attempt to re-connect to NATS.
-     * The default is
+     * The default is -1 which means unlimited.
      * {@value ConnectionOptionsFactory#DEFAULT_MAX_RECONNECT}
      */
     Optional<Integer> connectionAttempts();

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/SubscribeException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/SubscribeException.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.client;
+
+public class SubscribeException extends RuntimeException {
+
+    public SubscribeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/SubscripeException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/SubscripeException.java
@@ -1,8 +1,0 @@
-package io.quarkiverse.reactive.messaging.nats.jetstream.client;
-
-public class SubscripeException extends RuntimeException {
-
-    public SubscripeException(Throwable cause) {
-        super(cause);
-    }
-}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/configuration/ConnectionOptionsFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/configuration/ConnectionOptionsFactory.java
@@ -10,7 +10,7 @@ import io.nats.client.Options;
 import io.vertx.mutiny.core.Vertx;
 
 public class ConnectionOptionsFactory {
-    public static final int DEFAULT_MAX_RECONNECT = Integer.MAX_VALUE;
+    public static final int DEFAULT_MAX_RECONNECT = -1;
 
     public Options create(final ConnectionConfiguration configuration,
             final io.nats.client.ConnectionListener connectionListener,

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/configuration/PullConsumerConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/configuration/PullConsumerConfiguration.java
@@ -9,8 +9,6 @@ public interface PullConsumerConfiguration<T> {
 
     Integer batchSize();
 
-    Integer rePullAt();
-
     Optional<Integer> maxWaiting();
 
     ConsumerConfiguration<T> consumerConfiguration();

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/DefaultMessagePullPublisherConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/DefaultMessagePullPublisherConfiguration.java
@@ -39,7 +39,7 @@ public class DefaultMessagePullPublisherConfiguration<T> implements MessagePullP
     @Override
     public Duration maxExpires() {
         final var converter = new DurationConverter();
-        return configuration.getPullMaxExpires().map(converter::convert).orElse(Duration.ZERO);
+        return configuration.getPullMaxExpires().map(converter::convert).orElse(null);
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/DefaultMessagePullPublisherConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/DefaultMessagePullPublisherConfiguration.java
@@ -48,11 +48,6 @@ public class DefaultMessagePullPublisherConfiguration<T> implements MessagePullP
     }
 
     @Override
-    public Integer rePullAt() {
-        return configuration.getPullRePullAt();
-    }
-
-    @Override
     public Optional<Integer> maxWaiting() {
         return configuration.getPullMaxWaiting();
     }


### PR DESCRIPTION
JNats automatic reconnection to server only works for simplified api usage. So the subscriptions did not reconnect as expected.

Also, JNats has a bug with max integer. It never does reconnect if that value is used. Changed to -1 in maxAttempts as that means endless. Bug is already submitted to Nats on this.