### PR TITLE
Expose NatsConnection

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/Connection.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/Connection.java
@@ -12,6 +12,8 @@ import io.smallrye.mutiny.Uni;
 
 public interface Connection<T> extends AutoCloseable {
 
+    io.nats.client.Connection getNatsConnection();
+
     boolean isConnected();
 
     List<ConnectionListener> listeners();

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/DefaultConnection.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/DefaultConnection.java
@@ -68,6 +68,11 @@ class DefaultConnection<T> implements Connection<T> {
     }
 
     @Override
+    public io.nats.client.Connection getNatsConnection() {
+        return connection;
+    }
+
+    @Override
     public boolean isConnected() {
         return CONNECTED.equals(connection.getStatus());
     }


### PR DESCRIPTION
Fixes #297

```java
    try (final var connection = connectionFactory.create(ConnectionConfiguration.of(natsConfiguration)).await()
                                                 .atMost(Duration.ofSeconds(30))) {
      //use it wisely
      var natsConnection = connection.getNatsConnection();
    } catch (Exception e) {
      log.error(e);
    }
```