### PR TITLE
Add NackMetadata support for delayed message nack

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/api/NackMetadata.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/api/NackMetadata.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.client.api;
+
+import java.time.Duration;
+import java.util.*;
+
+import lombok.Builder;
+
+@Builder
+public record NackMetadata(Duration delayWait) {
+
+    public Optional<Duration> delayWaitOptional() {
+        return Optional.ofNullable(delayWait);
+    }
+}


### PR DESCRIPTION
As the NATS documentation states, the backoff does not kick in when using nak. This PR enables a way to call nakWithDelay

![image](https://github.com/user-attachments/assets/a56b6582-bc01-4cc9-a15a-55627be0a986)
