### PR TITLE
replaced deprecated native compile flag

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -101,7 +101,7 @@
             </build>
             <properties>
                 <skipITs>false</skipITs>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Removed the warning during native compile

Warning:  [io.quarkus.deployment.configuration] Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]