### PR TITLE
Fix: Add `getNackWithMetadata()` method to `SubscribeMessage` class

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/api/SubscribeMessage.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/api/SubscribeMessage.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -114,6 +115,11 @@ public class SubscribeMessage<T> implements JetStreamMessage<T> {
 
     @Override
     public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
+    }
+
+    @Override
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 


### PR DESCRIPTION
Implements the missing `getNackWithMetadata()` method that returns a `BiFunction<Throwable, Metadata, CompletionStage<Void>>` for handling NACK operations with metadata support in NATS JetStream subscriptions.

### Changes:
- Add `getNackWithMetadata()` override method to `SubscribeMessage` class
- Delegates to existing `nack()` method to maintain consistency with other metadata operations
