### PR TITLE
docs: escape {host} and {port} attribute references

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -140,7 +140,7 @@ The stream and Key/Value store configuration are optional. If they are omitted, 
 [cols="4",options="header"]
 |======
 | Property Name | Description | Type | Default Value
-| quarkus.messaging.nats.connection.servers | A comma-separated list of URI's nats://{host}:{port} to use for establishing the initial connection to the NATS cluster. | String | nats://localhost:4222
+| quarkus.messaging.nats.connection.servers | A comma-separated list of URI's nats://\{host\}:\{port\} to use for establishing the initial connection to the NATS cluster. | String | nats://localhost:4222
 | quarkus.messaging.nats.connection.username | The username to connect to the NATS server | String |
 | quarkus.messaging.nats.connection.password | The password to connect to the NATS server | String |
 | quarkus.messaging.nats.connection.token | The token to connect to the NATS server | String |


### PR DESCRIPTION
## Summary
- Escape `{host}` and `{port}` in the NATS connection URI template `nats://{host}:{port}` to prevent AsciiDoc from interpreting them as missing attributes
- Fixes 2 warnings during the quarkiverse-docs Antora build

## Test plan
- [ ] Verify the configuration table renders the URI template correctly