### PR TITLE
Fix RejectedExecutionException during shutdown

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/JetStreamConnector.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/JetStreamConnector.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -17,6 +18,7 @@ import io.quarkiverse.reactive.messaging.nats.jetstream.configuration.Configurat
 import io.quarkiverse.reactive.messaging.nats.jetstream.processors.MessageProcessor;
 import io.quarkiverse.reactive.messaging.nats.jetstream.processors.publisher.MessagePublisherProcessorFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.processors.subscriber.MessageSubscriberProcessorFactory;
+import io.quarkus.runtime.ShutdownEvent;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.connector.InboundConnector;
 import io.smallrye.reactive.messaging.connector.OutboundConnector;
@@ -92,6 +94,10 @@ public class JetStreamConnector implements InboundConnector, OutboundConnector, 
                 processor.health().healthy(),
                 processor.health().message())));
         return builder.build();
+    }
+
+    public void onShutdown(@Observes ShutdownEvent event) {
+        processors.forEach(MessageProcessor::stop);
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/MessageProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/MessageProcessor.java
@@ -8,4 +8,6 @@ public interface MessageProcessor {
 
     Health health();
 
+    default void stop() {
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/MessagePublisherProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/publisher/MessagePublisherProcessor.java
@@ -19,6 +19,7 @@ public abstract class MessagePublisherProcessor<T> implements MessageProcessor, 
     private final AtomicReference<Health> health;
     private final Duration retryBackoff;
     private final Class<T> payloadType;
+    private volatile boolean stopped = false;
 
     public MessagePublisherProcessor(final String channel,
             final String stream,
@@ -63,6 +64,11 @@ public abstract class MessagePublisherProcessor<T> implements MessageProcessor, 
         health.set(new Health(false, String.format("Publish processor unhealthy for channel: %s", channel())));
     }
 
+    @Override
+    public void stop() {
+        this.stopped = true;
+    }
+
     public Multi<org.eclipse.microprofile.reactive.messaging.Message<T>> publisher() {
         return subscribe(payloadType)
                 .onSubscription()
@@ -70,7 +76,7 @@ public abstract class MessagePublisherProcessor<T> implements MessageProcessor, 
                         .set(new Health(true, String.format("Publish processor healthy for channel: %s", channel()))))
                 .onFailure()
                 .invoke(failure -> log.errorf(failure, "Failed to subscribe with message: %s", failure.getMessage()))
-                .onFailure().retry().withBackOff(retryBackoff).indefinitely();
+                .onFailure().retry().withBackOff(retryBackoff).until(failure -> stopped);
     }
 
     protected abstract Multi<Message<T>> subscribe(Class<T> payloadType);

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/subscriber/MessageSubscriberProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/processors/subscriber/MessageSubscriberProcessor.java
@@ -23,6 +23,8 @@ public class MessageSubscriberProcessor<T> implements MessageProcessor, PublishL
     private final Client client;
     private final Duration retryBackoff;
 
+    private volatile boolean stopped = false;
+
     private final AtomicReference<Health> health;
 
     public MessageSubscriberProcessor(final String channel,
@@ -44,7 +46,12 @@ public class MessageSubscriberProcessor<T> implements MessageProcessor, PublishL
 
     private Multi<Message<T>> subscribe(Multi<Message<T>> subscription) {
         return client.publish(subscription, stream, subject, this)
-                .onFailure().retry().withBackOff(retryBackoff).indefinitely();
+                .onFailure().retry().withBackOff(retryBackoff).until(failure -> stopped);
+    }
+
+    @Override
+    public void stop() {
+        this.stopped = true;
     }
 
     @Override


### PR DESCRIPTION
Prevents java.util.concurrent.RejectedExecutionException and "Error Occurred After Shutdown" logs by stopping infinite retries when the application shuts down.


### Description
When the application shuts down, the event executor may be terminated while the NATS JetStream processors are still attempting to retry failed subscriptions. This leads to RejectedExecutionException as the retry logic attempts to schedule new tasks on a stopped executor.
This PR introduces a stop() mechanism for processors and integrates it with the Quarkus ShutdownEvent to ensure retries cease before the executor is fully terminated.


### Changes
- MessageProcessor: Added stop() method to the interface to allow lifecycle management of processors.
- MessagePublisherProcessor & MessageSubscriberProcessor: 
- Introduced a stopped volatile flag.
- Replaced .retry().indefinitely() with .retry().until(this::isStopped) (or equivalent predicate) to break the retry loop on shutdown.
- JetStreamConnector: Added an observer for ShutdownEvent that calls stop() on all registered processors.