### PR TITLE
Add JetStream request/reply support (JetStreamRequestReply)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ release.properties
 /qodana.yaml
 
 CLAUDE.md
+
+/.opencode/
+/openspec/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ This is a multi-module Maven project with a standard Quarkus extension structure
 - Located in `runtime/src/main/java/.../processors/`
 - Each processor tracks its own health status
 
+**Request/Reply** (`runtime/src/main/java/.../reply/`):
+- **JetStreamRequestReply**: request/reply emitter injectable via `@Channel`; publishes on the channel subject and awaits a correlation-matched reply on a shared reply subject (non-durable consumer per instance, `deliver_policy=new`)
+- **JetStreamRequestReplyFactory** / **JetStreamRequestReplyProducer**: SmallRye `EmitterFactory` SPI + CDI producer that make the type injectable; emitters are closed on shutdown
+- **CorrelationIdHandler** / **ReplyFailureHandler**: pluggable correlation-id and failure strategies, selected per channel via `reply.correlation-id.handler` / `reply.failure.handler`
+- See the user documentation (Request/Reply section in `docs/modules/ROOT/pages/index.adoc`) for examples and the `reply.*` configuration reference
+
 **Client Layer** (`runtime/src/main/java/.../client/`):
 - **connection/**: Manages NATS connections and configuration
 - **context/**: Handles JetStream context creation and management

--- a/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/deployment/JetStreamProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/deployment/JetStreamProcessor.java
@@ -18,6 +18,9 @@ import io.quarkiverse.reactive.messaging.nats.jetstream.client.tracing.OpenTelem
 import io.quarkiverse.reactive.messaging.nats.jetstream.configuration.JetStreamRecorder;
 import io.quarkiverse.reactive.messaging.nats.jetstream.processors.publisher.MessagePublisherProcessorFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.processors.subscriber.MessageSubscriberProcessorFactory;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestReplyFactory;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestReplyProducer;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.UuidCorrelationIdHandler;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -85,6 +88,10 @@ class JetStreamProcessor {
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(MessagePublisherProcessorFactory.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(MessageSubscriberProcessorFactory.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(TlsContextFactoryImpl.class));
+
+        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(JetStreamRequestReplyFactory.class));
+        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(JetStreamRequestReplyProducer.class));
+        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(UuidCorrelationIdHandler.class));
     }
 
     @BuildStep

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/FailOnFailHandler.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/FailOnFailHandler.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.test.reply;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.ReplyFailureHandler;
+import io.smallrye.common.annotation.Identifier;
+
+/**
+ * Test failure handler: treats any reply payload containing 'FAIL' as a business failure.
+ */
+@ApplicationScoped
+@Identifier("fail-on-fail")
+public class FailOnFailHandler implements ReplyFailureHandler {
+
+    @Override
+    public Optional<Throwable> failure(Object payload) {
+        if (payload instanceof String s && s.contains("FAIL")) {
+            return Optional.of(new IllegalStateException(s));
+        }
+        return Optional.empty();
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/FixedCorrelationIdHandler.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/FixedCorrelationIdHandler.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.test.reply;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.CorrelationIdHandler;
+import io.smallrye.common.annotation.Identifier;
+
+/**
+ * Test correlation id handler: always generates the same id so tests can publish matching replies out-of-band.
+ */
+@ApplicationScoped
+@Identifier("fixed-id")
+public class FixedCorrelationIdHandler implements CorrelationIdHandler {
+
+    public static final String ID = "fixed-correlation";
+
+    @Override
+    public String generate() {
+        return ID;
+    }
+
+    @Override
+    public Optional<String> parse(String value) {
+        return Optional.of(value);
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplierBean.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplierBean.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.test.reply;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Replier: consumes requests on 'orders' and echoes them, preserving the incoming message metadata so that the
+ * requestor's advertised reply subject and correlation id drive auto-routing.
+ */
+@ApplicationScoped
+public class ReplierBean {
+
+    @Incoming("replies-in")
+    @Outgoing("replies-out")
+    public Uni<Message<String>> reply(Message<String> msg) {
+        return Uni.createFrom().completionStage(msg.ack())
+                .chain(() -> Uni.createFrom().item(
+                        Message.of("echo:" + msg.getPayload()).withMetadata(msg.getMetadata())));
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplyResource.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplyResource.java
@@ -1,0 +1,199 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.test.reply;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.Client;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.PublishMessageMetadata;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestReply;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestTimeoutException;
+
+@ApplicationScoped
+@Path("/rr")
+public class ReplyResource {
+
+    private static final Duration BOUND = Duration.ofSeconds(10);
+
+    @Inject
+    @Channel("requests")
+    JetStreamRequestReply<String, String> requestorA;
+
+    @Inject
+    @Channel("requests-2")
+    JetStreamRequestReply<String, String> requestorB;
+
+    @Inject
+    @Channel("requests-slow")
+    JetStreamRequestReply<String, String> requestorSlow;
+
+    @Inject
+    @Channel("requests-bad")
+    JetStreamRequestReply<String, String> requestorBad;
+
+    @Inject
+    @Channel("requests-fail")
+    JetStreamRequestReply<String, String> requestorFail;
+
+    @Inject
+    @Channel("requests-fh")
+    JetStreamRequestReply<String, String> requestorFh;
+
+    @Inject
+    @Channel("requests-missing")
+    JetStreamRequestReply<String, String> requestorMissing;
+
+    @Inject
+    Client client;
+
+    @POST
+    @Path("/a/{value}")
+    public Object a(@PathParam("value") final String value) {
+        return invoke(requestorA, value);
+    }
+
+    @POST
+    @Path("/b/{value}")
+    public Object b(@PathParam("value") final String value) {
+        return invoke(requestorB, value);
+    }
+
+    @POST
+    @Path("/slow/{value}")
+    public Object slow(@PathParam("value") final String value) {
+        return invoke(requestorSlow, value);
+    }
+
+    @POST
+    @Path("/bad")
+    public Object bad() {
+        return invoke(requestorBad, "x");
+    }
+
+    @POST
+    @Path("/fail")
+    public Object fail() {
+        return invoke(requestorFail, "hello-fail");
+    }
+
+    @POST
+    @Path("/missing")
+    public Object missing() {
+        return invoke(requestorMissing, "hello-missing");
+    }
+
+    @POST
+    @Path("/fh/{value}")
+    public Object fh(@PathParam("value") final String value) {
+        return invoke(requestorFh, value);
+    }
+
+    @GET
+    @Path("/pending")
+    public Map<String, Integer> pending() {
+        final var map = new LinkedHashMap<String, Integer>();
+        map.put("a", requestorA.getPendingReplies().size());
+        map.put("b", requestorB.getPendingReplies().size());
+        map.put("slow", requestorSlow.getPendingReplies().size());
+        map.put("fh", requestorFh.getPendingReplies().size());
+        map.put("missing", requestorMissing.getPendingReplies().size());
+        return map;
+    }
+
+    @POST
+    @Path("/add-subject/{subject}")
+    public Response addSubject(@PathParam("subject") final String subject) {
+        try {
+            client.addSubject("rr", subject).await().atMost(BOUND);
+        } catch (RuntimeException e) {
+            // Subject already present - fine.
+        }
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/add-stream-missing")
+    public Response addStreamMissing() {
+        final var configuration = io.quarkiverse.reactive.messaging.nats.jetstream.client.stream.StreamConfigurationImpl
+                .builder()
+                .name("missing")
+                .description(java.util.Optional.empty())
+                .subjects(java.util.Set.of("missing-req", "missing.replies"))
+                .replicas(1)
+                .storageType(io.nats.client.api.StorageType.File)
+                .retentionPolicy(io.nats.client.api.RetentionPolicy.Limits)
+                .compressionOption(io.nats.client.api.CompressionOption.None)
+                .maximumConsumers(java.util.Optional.empty())
+                .maximumMessages(java.util.Optional.empty())
+                .maximumMessagesPerSubject(java.util.Optional.empty())
+                .maximumBytes(java.util.Optional.empty())
+                .maximumAge(java.util.Optional.empty())
+                .maximumMessageSize(java.util.Optional.empty())
+                .templateOwner(java.util.Optional.empty())
+                .discardPolicy(java.util.Optional.of(io.nats.client.api.DiscardPolicy.Old))
+                .duplicateWindow(java.util.Optional.empty())
+                .allowRollup(java.util.Optional.empty())
+                .allowDirect(java.util.Optional.empty())
+                .mirrorDirect(java.util.Optional.empty())
+                .denyDelete(java.util.Optional.empty())
+                .denyPurge(java.util.Optional.empty())
+                .discardNewPerSubject(java.util.Optional.empty())
+                .firstSequence(java.util.Optional.empty())
+                .build();
+        client.addStreamIfAbsent(configuration).await().atMost(BOUND);
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/reply-missing/{id}")
+    public Response replyMissing(@PathParam("id") final String id) {
+        final var metadata = PublishMessageMetadata.builder()
+                .stream("missing")
+                .subject("missing.replies")
+                .headers(Map.of(JetStreamRequestReply.CORRELATION_ID_HEADER, List.of(id)))
+                .build();
+        client.publish(Message.of("echo:hello-missing").addMetadata(metadata), "missing", "missing.replies")
+                .await().atMost(BOUND);
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/late/{id}")
+    public Response late(@PathParam("id") final String id) {
+        final var metadata = PublishMessageMetadata.builder()
+                .stream("rr")
+                .subject("slow.replies")
+                .headers(Map.of(JetStreamRequestReply.CORRELATION_ID_HEADER, List.of(id)))
+                .build();
+        client.publish(Message.of("late-reply").addMetadata(metadata), "rr", "slow.replies")
+                .await().atMost(BOUND);
+        return Response.ok().build();
+    }
+
+    private Object invoke(final JetStreamRequestReply<String, String> requestor, final String value) {
+        try {
+            return requestor.request(value).await().atMost(BOUND);
+        } catch (RuntimeException e) {
+            final var body = new LinkedHashMap<String, Object>();
+            body.put("exception", e.getClass().getSimpleName());
+            body.put("message", String.valueOf(e.getMessage()));
+            if (e instanceof JetStreamRequestTimeoutException timeout) {
+                body.put("correlationId", timeout.getCorrelationId());
+            }
+            return Response.serverError().entity(body).build();
+        }
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplyTest.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/test/reply/ReplyTest.java
@@ -1,0 +1,171 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.test.reply;
+
+import static io.restassured.RestAssured.*;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+import io.restassured.parsing.Parser;
+
+class ReplyTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ReplierBean.class, FailOnFailHandler.class, FixedCorrelationIdHandler.class,
+                            ReplyResource.class))
+            .withConfigurationResource("application-reply.properties");
+
+    @BeforeEach
+    void setup() {
+        defaultParser = Parser.JSON;
+    }
+
+    @Test
+    void roundTrip() {
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .pathParam("value", "hello")
+                .post("/rr/a/{value}")
+                .then()
+                .statusCode(200)
+                .body(equalTo("echo:hello"));
+
+        given().get("/rr/pending").then().statusCode(200).body("a", equalTo(0));
+    }
+
+    @Test
+    void twoRequestorsOnlyReceiveOwnReplies() {
+        // Both requestors share the reply subject; each must complete with only its own correlation id.
+        given().pathParam("value", "one").post("/rr/a/{value}").then().statusCode(200).body(equalTo("echo:one"));
+        given().pathParam("value", "two").post("/rr/b/{value}").then().statusCode(200).body(equalTo("echo:two"));
+
+        given().get("/rr/pending").then().statusCode(200)
+                .body("a", equalTo(0), "b", equalTo(0));
+    }
+
+    @Test
+    void timeoutFailsAndLateReplyIsDropped() {
+        // Reply subject must be covered so the reply consumer can be created; nobody consumes 'slow'.
+        given().pathParam("subject", "slow.replies").post("/rr/add-subject/{subject}").then().statusCode(200);
+
+        final var response = given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .pathParam("value", "slow-1")
+                .post("/rr/slow/{value}")
+                .then()
+                .statusCode(500)
+                .extract();
+
+        final Map<String, Object> body = response.as(Map.class);
+        assertEquals("JetStreamRequestTimeoutException", body.get("exception"));
+        final var correlationId = (String) body.get("correlationId");
+        assertNotNull(correlationId);
+        assertFalse(correlationId.isBlank());
+
+        // Pending entry removed on timeout (guards the leak fix).
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> (Integer) get("/rr/pending").as(Map.class).get("slow") == 0);
+
+        // A late reply for the timed-out correlation id must be discarded without error.
+        given().pathParam("id", correlationId).post("/rr/late/{id}").then().statusCode(200);
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> (Integer) get("/rr/pending").as(Map.class).get("slow") == 0);
+
+        // The requestor is still usable afterwards.
+        given().pathParam("value", "slow-2").post("/rr/slow/{value}").then().statusCode(500)
+                .body("exception", equalTo("JetStreamRequestTimeoutException"));
+    }
+
+    @Test
+    void publishFailurePropagates() {
+        // Reply subject covered, request subject not: consumer creation succeeds, the publish must fail.
+        given().pathParam("subject", "bad.replies").post("/rr/add-subject/{subject}").then().statusCode(200);
+
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .post("/rr/bad")
+                .then()
+                .statusCode(500)
+                .body("exception", equalTo("JetStreamRequestPublishException"));
+    }
+
+    @Test
+    void succeedsOnceReplySubjectIsCovered() {
+        // Reply subject not covered yet: the request is published but no reply can ever arrive, so it times out.
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .post("/rr/fail")
+                .then()
+                .statusCode(500)
+                .body("exception", equalTo("JetStreamRequestTimeoutException"));
+
+        // Extend stream coverage, then the next request must succeed.
+        given().pathParam("subject", "fail.replies").post("/rr/add-subject/{subject}").then().statusCode(200);
+
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .post("/rr/fail")
+                .then()
+                .statusCode(200)
+                .body(equalTo("echo:hello-fail"));
+    }
+
+    @Test
+    void reSubscribesAfterInitialSubscriptionFailure() throws Exception {
+        // Stream does not exist yet: the first request must fail with a subscription error.
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .post("/rr/missing")
+                .then()
+                .statusCode(500)
+                .body("exception", equalTo("JetStreamRequestSubscriptionException"));
+
+        // Create the stream, then the next request must re-subscribe and complete once a reply arrives.
+        given().post("/rr/add-stream-missing").then().statusCode(200);
+
+        final var result = new java.util.concurrent.CompletableFuture<String>();
+        final var thread = new Thread(() -> {
+            try {
+                final var response = given().post("/rr/missing").then().extract();
+                if (response.statusCode() == 200) {
+                    result.complete(response.body().asString());
+                } else {
+                    result.completeExceptionally(new AssertionError("expected 200 but was " + response.statusCode() + ": "
+                            + response.asString()));
+                }
+            } catch (RuntimeException e) {
+                result.completeExceptionally(e);
+            }
+        }, "request-missing");
+        thread.start();
+
+        // The request is in flight (re-subscribed and waiting for a reply): publish the matching reply out-of-band.
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> Integer.valueOf(1).equals(get("/rr/pending").as(Map.class).get("missing")));
+        given().pathParam("id", FixedCorrelationIdHandler.ID).post("/rr/reply-missing/{id}").then().statusCode(200);
+
+        assertEquals("echo:hello-missing", result.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void failureHandlerPropagatesAndPendingIsCleared() {
+        given().filters(new RequestLoggingFilter(), new ResponseLoggingFilter())
+                .pathParam("value", "please FAIL now")
+                .post("/rr/fh/{value}")
+                .then()
+                .statusCode(500)
+                .body("exception", equalTo("IllegalStateException"));
+
+        given().get("/rr/pending").then().statusCode(200).body("fh", equalTo(0));
+    }
+
+}

--- a/deployment/src/test/resources/application-reply.properties
+++ b/deployment/src/test/resources/application-reply.properties
@@ -1,0 +1,60 @@
+# Stream initially covers request subjects and the default reply subject of requestors A/B; other reply subjects are added at runtime by the tests via /rr/add-subject
+quarkus.messaging.nats.streams.rr.configuration.subjects=orders,slow,orders.replies
+
+# Replier push consumer for 'orders'
+quarkus.messaging.nats.streams.rr.push-consumers.rr-replier.consumer-configuration.filter-subjects=orders
+quarkus.messaging.nats.streams.rr.push-consumers.rr-replier.consumer-configuration.durable=true
+quarkus.messaging.nats.streams.rr.push-consumers.rr-replier.push-configuration.deliver-subject=_deliver.rr
+
+# Requestor A - success path (reply subject derived as orders.replies)
+mp.messaging.outgoing.requests.connector=quarkus-jetstream
+mp.messaging.outgoing.requests.stream=rr
+mp.messaging.outgoing.requests.subject=orders
+
+# Requestor B - second instance, same wiring as A
+mp.messaging.outgoing.requests-2.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-2.stream=rr
+mp.messaging.outgoing.requests-2.subject=orders
+
+# Timeout requestor - nobody consumes 'slow', so no reply ever arrives
+mp.messaging.outgoing.requests-slow.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-slow.stream=rr
+mp.messaging.outgoing.requests-slow.subject=slow
+mp.messaging.outgoing.requests-slow.reply.timeout=300
+
+# Publish-failure requestor - reply subject is covered, the request subject is not
+mp.messaging.outgoing.requests-bad.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-bad.stream=rr
+mp.messaging.outgoing.requests-bad.subject=no-such-subject
+mp.messaging.outgoing.requests-bad.reply.subject=bad.replies
+mp.messaging.outgoing.requests-bad.reply.timeout=2000
+
+# Late-coverage requestor - reply subject is not covered until the test adds it; the first request times out
+mp.messaging.outgoing.requests-fail.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-fail.stream=rr
+mp.messaging.outgoing.requests-fail.subject=orders
+mp.messaging.outgoing.requests-fail.reply.subject=fail.replies
+mp.messaging.outgoing.requests-fail.reply.timeout=300
+
+# Re-subscribe requestor - stream does not exist until the test creates it; the first request fails with a subscription error
+mp.messaging.outgoing.requests-missing.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-missing.stream=missing
+mp.messaging.outgoing.requests-missing.subject=missing-req
+mp.messaging.outgoing.requests-missing.reply.subject=missing.replies
+mp.messaging.outgoing.requests-missing.reply.timeout=8000
+mp.messaging.outgoing.requests-missing.reply.correlation-id.handler=fixed-id
+
+# Failure-handler requestor - replier echoes the payload, handler fails on 'FAIL'
+mp.messaging.outgoing.requests-fh.connector=quarkus-jetstream
+mp.messaging.outgoing.requests-fh.stream=rr
+mp.messaging.outgoing.requests-fh.subject=orders
+mp.messaging.outgoing.requests-fh.reply.failure.handler=fail-on-fail
+
+# Replier channels
+mp.messaging.incoming.replies-in.connector=quarkus-jetstream
+mp.messaging.incoming.replies-in.stream=rr
+mp.messaging.incoming.replies-in.consumer=rr-replier
+
+mp.messaging.outgoing.replies-out.connector=quarkus-jetstream
+mp.messaging.outgoing.replies-out.stream=rr
+mp.messaging.outgoing.replies-out.subject=orders.replies

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -71,6 +71,111 @@ public class DataConsumer {
 ----
 If you want more examples, please take a look at the tests of the extension.
 
+== Request/Reply (JetStreamRequestReply)
+
+Instead of plain pub/sub, you can use request/reply semantics: inject `JetStreamRequestReply<Req, Rep>` on an outgoing channel and call `request()`. Each call publishes the payload on the channel's subject and returns a `Uni` that completes when the matching reply arrives, or fails with `JetStreamRequestTimeoutException` if no reply arrives within `reply.timeout`.
+
+IMPORTANT: The stream MUST cover both the request subject and the reply subject. If the reply subject is not covered by the stream, replies can never be persisted or delivered and every request fails with a timeout (NATS happily accepts creating the consumer either way). If the stream does not exist at all, the first request fails with `JetStreamRequestSubscriptionException`; the next request re-subscribes automatically.
+
+=== Requestor
+
+Configure an outgoing channel for the requests:
+
+----
+mp.messaging.outgoing.orders.connector=quarkus-jetstream
+mp.messaging.outgoing.orders.stream=orders
+mp.messaging.outgoing.orders.subject=orders
+# Optional - defaults to '<subject>.replies'
+mp.messaging.outgoing.orders.reply.subject=orders.replies
+# Optional - default 5000 ms
+mp.messaging.outgoing.orders.reply.timeout=10000
+----
+
+Then inject the requestor and send requests:
+
+----
+package outbound;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestReply;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class OrderService {
+
+    @Inject
+    @Channel("orders")
+    JetStreamRequestReply<String, String> requestor;
+
+    public Uni<String> placeOrder(String order) {
+        return requestor.request(order);
+    }
+
+}
+----
+
+=== Replier
+
+The replier is a plain `@Incoming`/`@Outgoing` method. The connector reads the reply subject advertised by the requestor (the `REPLY_SUBJECT` header) and routes the returned payload there automatically, echoing the correlation id (`REPLY_CORRELATION_ID`) so concurrent requestors never receive each other's replies:
+
+----
+package inbound;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+@ApplicationScoped
+public class OrderReplier {
+
+    @Incoming("orders-in")
+    @Outgoing("orders-out")
+    public String reply(String order) {
+        return "accepted:" + order;
+    }
+
+}
+----
+
+Bind the channels to the same stream:
+
+----
+mp.messaging.incoming.orders-in.connector=quarkus-jetstream
+mp.messaging.incoming.orders-in.stream=orders
+mp.messaging.incoming.orders-in.consumer=orders-replier
+
+mp.messaging.outgoing.orders-out.connector=quarkus-jetstream
+mp.messaging.outgoing.orders-out.stream=orders
+mp.messaging.outgoing.orders-out.subject=orders
+----
+
+=== Requestor channel configuration
+
+[cols="4",options="header"]
+|======
+| Property Name | Description | Type | Default Value
+| mp.messaging.outgoing.[channel-name].reply.subject | The subject on which replies are expected | String | `<subject>.replies`
+| mp.messaging.outgoing.[channel-name].reply.timeout | How long to wait for a reply in milliseconds | Long | 5000
+| mp.messaging.outgoing.[channel-name].reply.inactive-threshold | How long NATS keeps an idle request/reply consumer before reclaiming it, in milliseconds | Long | 60000
+| mp.messaging.outgoing.[channel-name].reply.correlation-id.handler | The `@Identifier` of the `CorrelationIdHandler` bean used to generate and parse correlation ids | String | uuid
+| mp.messaging.outgoing.[channel-name].reply.failure.handler | The `@Identifier` of the `ReplyFailureHandler` bean used to turn reply payloads into failures | String |
+|======
+
+The correlation id travels in the NATS message header `REPLY_CORRELATION_ID`; the requestor advertises its reply subject via the `REPLY_SUBJECT` header. Both names are fixed for this version.
+
+=== Scaling model and failure semantics
+
+- Every requestor instance creates its own *non-durable* consumer on the shared reply subject (`deliver_policy=new`, `max_deliver=1`) and receives every reply; replies are demultiplexed by correlation id and non-matches are acknowledged and discarded. This trades a little extra network traffic for zero instance identity: requestors and repliers can scale independently.
+- Idle consumers are reclaimed by NATS after `reply.inactive-threshold`, so no consumer leaks accumulate.
+- If publishing the request fails, the returned `Uni` fails with `JetStreamRequestPublishException`.
+- If a reply payload should be treated as an error, provide a CDI bean implementing `ReplyFailureHandler` (selected per channel via `reply.failure.handler`) and return the failure from it; the caller's `Uni` fails with that error.
+- To observe in-flight requests, use `JetStreamRequestReply.getPendingReplies()`; pending entries are removed on completion, failure, timeout and shutdown.
+
 == Using NATS Key/Value store
 If you want to use the Key/Value store in NATS, then configure your as follows:
 

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/JetStreamConnector.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/JetStreamConnector.java
@@ -32,6 +32,11 @@ import io.smallrye.reactive.messaging.health.HealthReporter;
 @ConnectorAttribute(name = "consumer", description = "The name of the consumer", direction = INCOMING, type = "String")
 @ConnectorAttribute(name = "payload-type", description = "The payload type", direction = INCOMING, type = "String")
 @ConnectorAttribute(name = "retry-backoff", description = "The retry backoff in milliseconds for retry processing messages", direction = INCOMING_AND_OUTGOING, type = "Long", defaultValue = "10000")
+@ConnectorAttribute(name = "reply.subject", description = "The subject on which replies are expected when using JetStreamRequestReply. Defaults to the channel subject with '.replies' appended.", direction = OUTGOING, type = "String")
+@ConnectorAttribute(name = "reply.timeout", description = "How long to wait for a reply in milliseconds when using JetStreamRequestReply", direction = OUTGOING, type = "Long", defaultValue = "5000")
+@ConnectorAttribute(name = "reply.inactive-threshold", description = "How long NATS keeps an idle request/reply consumer before reclaiming it, in milliseconds", direction = OUTGOING, type = "Long", defaultValue = "60000")
+@ConnectorAttribute(name = "reply.correlation-id.handler", description = "The @Identifier of the CorrelationIdHandler bean used to generate and parse correlation ids (default 'uuid')", direction = OUTGOING, type = "String")
+@ConnectorAttribute(name = "reply.failure.handler", description = "The @Identifier of the ReplyFailureHandler bean used to turn reply payloads into failures", direction = OUTGOING, type = "String")
 public class JetStreamConnector implements InboundConnector, OutboundConnector, HealthReporter {
     public static final String CONNECTOR_NAME = "quarkus-jetstream";
 

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/publisher/PublisherAwareImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/client/publisher/PublisherAwareImpl.java
@@ -15,12 +15,14 @@ import io.nats.client.impl.Headers;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.ClientException;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.PublishMessageMetadata;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.SerializedPayload;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.SubscribeMessageMetadata;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.connection.Connection;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.connection.JetStreamAware;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.context.ContextAware;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.mapper.PayloadMapper;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.tracing.TracerFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.tracing.TracerType;
+import io.quarkiverse.reactive.messaging.nats.jetstream.reply.JetStreamRequestReply;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.tuples.Tuple2;
@@ -104,6 +106,15 @@ public class PublisherAwareImpl extends ContextAware implements PublisherAware, 
     }
 
     private <T> String subject(final Message<T> message, final String subject) {
+        // Replier auto-routing: a reply flowing from an incoming channel carries the requestor's advertised reply
+        // subject; it wins over the channel-configured subject (which may only be a prefix).
+        final var replySubject = message.getMetadata().get(SubscribeMessageMetadata.class)
+                .map(subscribeMetadata -> subscribeMetadata.headers().get(JetStreamRequestReply.REPLY_SUBJECT_HEADER))
+                .filter(values -> !values.isEmpty())
+                .map(values -> values.get(0));
+        if (replySubject.isPresent()) {
+            return replySubject.get();
+        }
         final var result = message.getMetadata().get(PublishMessageMetadata.class)
                 .map(PublishMessageMetadata::subject)
                 .orElse(subject);
@@ -123,6 +134,12 @@ public class PublisherAwareImpl extends ContextAware implements PublisherAware, 
         final var headers = new HashMap<>(message.getMetadata().get(PublishMessageMetadata.class)
                 .map(PublishMessageMetadata::headers)
                 .orElseGet(Map::of));
+        // Replier auto-routing: carry the requestor's correlation id back on the reply so it can be matched. An
+        // explicitly set header always wins.
+        message.getMetadata().get(SubscribeMessageMetadata.class)
+                .map(subscribeMetadata -> subscribeMetadata.headers().get(JetStreamRequestReply.CORRELATION_ID_HEADER))
+                .filter(values -> !values.isEmpty())
+                .ifPresent(values -> headers.putIfAbsent(JetStreamRequestReply.CORRELATION_ID_HEADER, values));
         headers.put(MESSAGE_TYPE_HEADER, List.of(message.getPayload().getClass().getName()));
         return headers;
     }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/CorrelationIdHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/CorrelationIdHandler.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.util.Optional;
+
+/**
+ * Strategy for generating and parsing correlation ids that pair requests with replies. Provide an alternate implementation
+ * as a CDI bean (for example one backed by OpenTelemetry trace context) and select it per channel with the
+ * {@code reply.correlation-id.handler} connector attribute. The default is {@link UuidCorrelationIdHandler}.
+ */
+public interface CorrelationIdHandler {
+
+    /** @return a new correlation id that will be placed in the {@link JetStreamRequestReply#CORRELATION_ID_HEADER} header */
+    String generate();
+
+    /**
+     * Parses a correlation id carried by an incoming reply.
+     *
+     * @param value the raw header value
+     * @return the parsed id, or empty if it is malformed and the message should be ignored
+     */
+    Optional<String> parse(String value);
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestPublishException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestPublishException.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+/**
+ * Raised when a request fails to publish on the request channel.
+ */
+public class JetStreamRequestPublishException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private final String channelName;
+
+    public JetStreamRequestPublishException(String channelName, Throwable cause) {
+        super("Failed to publish request on channel '" + channelName + "'", cause);
+        this.channelName = channelName;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReply.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReply.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.EmitterType;
+
+/**
+ * A reactive request/reply client for NATS JetStream. Inject it on the requestor side with a channel annotation, e.g.:
+ *
+ * <pre>
+ * {@code
+ * @Inject
+ * @Channel("requests")
+ * JetStreamRequestReply<String, JsonPojo> requestor;
+ * }
+ * </pre>
+ *
+ * Each call to {@link #request(Object)} publishes the payload on the annotated outgoing channel and returns a {@link Uni}
+ * that completes when a matching reply arrives on the configured (or derived) reply subject. Replies are matched to
+ * requests using a correlation id stored in the {@value #CORRELATION_ID_HEADER} message header; unmatched replies are
+ * ignored and acknowledged, so concurrent requestors never receive each other's replies.
+ */
+public interface JetStreamRequestReply<Req, Rep> extends EmitterType {
+
+    /** The NATS message header carrying the correlation id of an in-flight request. */
+    String CORRELATION_ID_HEADER = "REPLY_CORRELATION_ID";
+
+    /**
+     * The NATS message header a requestor uses to advertise the subject on which it expects its reply. Replier beans can
+     * simply return their response and the connector routes it there automatically, without explicit metadata.
+     */
+    String REPLY_SUBJECT_HEADER = "REPLY_SUBJECT";
+
+    /** Suffix appended to the channel subject to derive the default reply subject when none is configured. */
+    String DEFAULT_REPLY_SUBJECT_SUFFIX = ".replies";
+
+    long DEFAULT_TIMEOUT_MILLIS = 5_000L;
+
+    /**
+     * Default {@code reply.inactive-threshold} in milliseconds: how long NATS keeps an idle reply consumer before reclaiming
+     * it.
+     */
+    long DEFAULT_INACTIVE_THRESHOLD_MILLIS = 60_000L;
+
+    /**
+     * Sends a request and waits for the matching reply.
+     *
+     * @param payload the request payload published on the channel
+     * @return a {@link Uni} that completes with the deserialized reply, fails with
+     *         {@link JetStreamRequestTimeoutException} if no reply arrives within the configured timeout, or with the
+     *         failure returned by the configured {@link ReplyFailureHandler}
+     */
+    Uni<Rep> request(Req payload);
+
+    /**
+     * Sends a fully specified request message and waits for the matching reply.
+     *
+     * @param <M> the message type
+     * @param message the outgoing request message; its metadata may carry an explicit {@code subject} or headers that are
+     *        preserved on the published message
+     * @return a {@link Uni} that completes with the reply message (payload and NATS metadata) matching this request
+     */
+    <M extends Message<? extends Req>> Uni<Message<Rep>> request(M message);
+
+    /**
+     * @return an unmodifiable view of the correlation ids currently awaiting their reply, useful for observability
+     */
+    Map<String, PendingReply> getPendingReplies();
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyFactory.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+
+import org.eclipse.microprofile.config.Config;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.Client;
+import io.quarkus.runtime.ShutdownEvent;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.EmitterFactory;
+import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
+
+/**
+ * Creates {@link JetStreamRequestReply} emitters for channels whose injection type is
+ * {@code JetStreamRequestReply}. Handler beans are resolved lazily per channel so that different channels can use
+ * different correlation-id and failure handlers. Emitters are closed on application shutdown: their reply subscription is
+ * cancelled, the ephemeral consumer deleted and outstanding requests failed.
+ */
+@ApplicationScoped
+@EmitterFactoryFor(JetStreamRequestReply.class)
+public class JetStreamRequestReplyFactory implements EmitterFactory<JetStreamRequestReplyImpl<Object, Object>> {
+
+    private final Client client;
+    private final Config config;
+    private final Instance<CorrelationIdHandler> correlationIdHandlers;
+    private final Instance<ReplyFailureHandler> failureHandlers;
+
+    private final Set<JetStreamRequestReplyImpl<?, ?>> emitters = ConcurrentHashMap.newKeySet();
+
+    public JetStreamRequestReplyFactory(final Client client,
+            final Config config,
+            @Any Instance<CorrelationIdHandler> correlationIdHandlers,
+            @Any Instance<ReplyFailureHandler> failureHandlers) {
+        this.client = client;
+        this.config = config;
+        this.correlationIdHandlers = correlationIdHandlers;
+        this.failureHandlers = failureHandlers;
+    }
+
+    @Override
+    public JetStreamRequestReplyImpl<Object, Object> createEmitter(EmitterConfiguration configuration, long defaultBufferSize) {
+        final var emitter = new JetStreamRequestReplyImpl<>(configuration, client, config, correlationIdHandlers,
+                failureHandlers);
+        emitters.add(emitter);
+        return emitter;
+    }
+
+    void onShutdown(@Observes ShutdownEvent event) {
+        emitters.forEach(JetStreamRequestReplyImpl::close);
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyImpl.java
@@ -1,0 +1,413 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.nats.client.api.DeliverPolicy;
+import io.nats.client.api.ReplayPolicy;
+import io.quarkiverse.reactive.messaging.nats.jetstream.JetStreamConnector;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.Client;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.PublishMessageMetadata;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.api.SubscribeMessageMetadata;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.consumer.ConsumerConfigurationImpl;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.consumer.ConsumerListener;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.consumer.PushConfigurationImpl;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.reactive.messaging.EmitterConfiguration;
+import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterImpl;
+import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
+import io.smallrye.reactive.messaging.providers.impl.Configs;
+import lombok.extern.jbosslog.JBossLog;
+
+/**
+ * Default {@link JetStreamRequestReply} implementation. Requests are published with the standard SmallRye emitter path on
+ * the annotated channel; a lazily created ephemeral push consumer receives replies, matches them by correlation id and
+ * completes or fails the outstanding call. Unmatched replies (including traffic from other requestor instances) are
+ * acknowledged and dropped. If the reply subscription fails it is transparently re-created on the next request.
+ */
+@JBossLog
+public class JetStreamRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req> implements JetStreamRequestReply<Req, Rep> {
+
+    private final Client client;
+    private final String channelName;
+    private final String stream;
+    private final String replySubject;
+    private final long timeoutMillis;
+    private final Duration inactiveThreshold;
+    private final CorrelationIdHandler correlationIdHandler;
+    private final ReplyFailureHandler failureHandler;
+
+    private final Map<String, PendingReply> pendingReplies = new ConcurrentHashMap<>();
+
+    private final Object initLock = new Object();
+    private volatile CompletableFuture<Void> readyFuture;
+    private volatile boolean active;
+    private volatile boolean closed;
+    private volatile Cancellable replyCancellable;
+    private volatile String replyConsumerName;
+
+    public JetStreamRequestReplyImpl(final EmitterConfiguration config,
+            final Client client,
+            final Config mpConfig,
+            final Instance<CorrelationIdHandler> correlationIdHandlers,
+            final Instance<ReplyFailureHandler> failureHandlers) {
+        super(config, 1024L);
+        requireNonNull(client, "client");
+        this.client = client;
+        this.channelName = config.name();
+
+        final var connectorConfig = Configs.outgoing(mpConfig, JetStreamConnector.CONNECTOR_NAME, config.name());
+        this.stream = requiredConfig(connectorConfig, "stream", channelName);
+        this.replySubject = nonBlank(connectorConfig.getOptionalValue("reply.subject", String.class))
+                .orElse(requiredConfig(connectorConfig, "subject", channelName)
+                        + JetStreamRequestReply.DEFAULT_REPLY_SUBJECT_SUFFIX);
+        this.timeoutMillis = connectorConfig.getOptionalValue("reply.timeout", Long.class)
+                .orElse(JetStreamRequestReply.DEFAULT_TIMEOUT_MILLIS);
+        if (this.timeoutMillis <= 0) {
+            throw new IllegalArgumentException(
+                    "reply.timeout must be a positive number of milliseconds for channel '" + channelName + "'");
+        }
+
+        final var inactiveThresholdMillis = connectorConfig.getOptionalValue("reply.inactive-threshold", Long.class)
+                .orElse(JetStreamRequestReply.DEFAULT_INACTIVE_THRESHOLD_MILLIS);
+        if (inactiveThresholdMillis < 0) {
+            throw new IllegalArgumentException(
+                    "reply.inactive-threshold must not be negative for channel '" + channelName + "'");
+        }
+        this.inactiveThreshold = Duration.ofMillis(inactiveThresholdMillis);
+
+        final var correlationIdHandlerId = nonBlank(
+                connectorConfig.getOptionalValue("reply.correlation-id.handler", String.class))
+                .orElse(UuidCorrelationIdHandler.ID);
+        this.correlationIdHandler = resolveHandler(correlationIdHandlers, CorrelationIdHandler.class,
+                channelName, "reply.correlation-id.handler", correlationIdHandlerId);
+
+        final var failureHandlerId = nonBlank(connectorConfig.getOptionalValue("reply.failure.handler", String.class));
+        if (failureHandlerId.isPresent()) {
+            this.failureHandler = resolveHandler(failureHandlers, ReplyFailureHandler.class,
+                    channelName, "reply.failure.handler", failureHandlerId.get());
+        } else {
+            this.failureHandler = null;
+        }
+    }
+
+    @Override
+    public Uni<Rep> request(final Req payload) {
+        final Message<Req> message = Message.of(payload);
+        return request(message).onItem().transform(reply -> reply.getPayload());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public <M extends Message<? extends Req>> Uni<Message<Rep>> request(final M message) {
+        final var correlationId = correlationIdHandler.generate();
+        final var pending = new PendingReply(correlationId, Instant.now());
+        pendingReplies.put(correlationId, pending);
+
+        return Uni.createFrom().completionStage(ensureReady())
+                .chain(() -> publishAndAwaitReply(message, correlationId, pending))
+                .ifNoItem()
+                .after(Duration.ofMillis(timeoutMillis))
+                .failWith(() -> new JetStreamRequestTimeoutException(correlationId, timeoutMillis))
+                .onTermination().invoke(() -> pendingReplies.remove(correlationId));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Uni<Message<Rep>> publishAndAwaitReply(final Message<? extends Req> message, final String correlationId,
+            final PendingReply pending) {
+        // The emitter's send-Uni only completes once a downstream acknowledges the message; on a plain outgoing channel
+        // nobody does that, so we must not gate the reply future on it. Subscribe fire-and-forget and propagate any
+        // publication failure to the pending reply instead of waiting for the ack.
+        final var reply = Uni.createFrom().completionStage(pending.future())
+                .onItem().transform(m -> (Message<Rep>) m);
+        sendMessage(withCorrelationId(message, correlationId))
+                .subscribe()
+                .with(unused -> {
+                    // published (and acknowledged, if ever) - the reply future drives completion
+                }, failure -> pending.fail(new JetStreamRequestPublishException(channelName, failure)));
+        return reply;
+    }
+
+    @Override
+    public Map<String, PendingReply> getPendingReplies() {
+        return Map.copyOf(pendingReplies);
+    }
+
+    /**
+     * Shuts this emitter down: cancels the reply subscription, deletes the ephemeral consumer (best effort) and fails all
+     * outstanding requests with a {@link JetStreamRequestShutdownException}. Further calls to {@link #request(Object)} fail
+     * immediately. Idempotent; invoked by the factory on application shutdown.
+     */
+    public void close() {
+        synchronized (initLock) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+        }
+        resetSubscription();
+
+        final var consumerName = replyConsumerName;
+        if (consumerName != null) {
+            client.deleteConsumer(stream, consumerName).subscribe().with(unused -> {
+                // deleted
+            }, failure -> log.debugf(failure, "Could not delete JetStream request/reply consumer '%s'", consumerName));
+        }
+
+        for (final var pending : pendingReplies.values()) {
+            if (!pending.isDone()) {
+                pending.fail(new JetStreamRequestShutdownException(channelName));
+            }
+        }
+    }
+
+    private Uni<Void> publish(final Message<? extends Req> message, final String correlationId) {
+        return sendMessage(withCorrelationId(message, correlationId))
+                .onFailure().transform(failure -> new JetStreamRequestPublishException(channelName, failure));
+    }
+
+    /**
+     * Returns a future that completes once the reply consumer is created and subscribed. Initialization is single-flight:
+     * concurrent callers share one attempt, and a failed attempt is retried on the next call. Never blocks, so it is safe
+     * to invoke from any thread (including Vert.x event loops).
+     */
+    private CompletableFuture<Void> ensureReady() {
+        if (closed) {
+            final var failed = new CompletableFuture<Void>();
+            failed.completeExceptionally(new JetStreamRequestShutdownException(channelName));
+            return failed;
+        }
+        if (active) {
+            return CompletableFuture.completedFuture(null);
+        }
+        synchronized (initLock) {
+            if (closed) {
+                final var failed = new CompletableFuture<Void>();
+                failed.completeExceptionally(new JetStreamRequestShutdownException(channelName));
+                return failed;
+            }
+            if (active) {
+                return CompletableFuture.completedFuture(null);
+            }
+            final var current = readyFuture;
+            if (current != null && !current.isDone()) {
+                return current;
+            }
+            final var future = new CompletableFuture<Void>();
+            readyFuture = future;
+            startReplyConsumer(future);
+            return future;
+        }
+    }
+
+    private void startReplyConsumer(final CompletableFuture<Void> future) {
+        final var consumerName = "rr-reply-" + channelName + "-" + UUID.randomUUID();
+        replyConsumerName = consumerName;
+        // A placeholder deliver subject makes the consumer push-based on the server; the client rebinds it to its own
+        // inbox when subscribing. It must not be covered by any stream so nothing is delivered there.
+        final var deliverSubject = "_js_reply." + consumerName;
+
+        final var consumerConfiguration = ConsumerConfigurationImpl.builder()
+                .name(consumerName)
+                .stream(stream)
+                .durable(false)
+                .filterSubjects(List.of(replySubject))
+                .ackWait(Optional.empty())
+                .deliverPolicy(DeliverPolicy.New)
+                .startSequence(Optional.empty())
+                .startTime(Optional.empty())
+                .description(Optional.empty())
+                .inactiveThreshold(Optional.of(inactiveThreshold))
+                .maxAckPending(Optional.empty())
+                .maxDeliver(Optional.of(1L))
+                .replayPolicy(ReplayPolicy.Instant)
+                .replicas(Optional.empty())
+                .memoryStorage(Optional.empty())
+                .sampleFrequency(Optional.empty())
+                .metadata(Map.of())
+                .backoff(Optional.empty())
+                .pauseUntil(Optional.empty())
+                .acknowledgeTimeout(Duration.ofSeconds(1))
+                .build();
+
+        final var pushConfiguration = PushConfigurationImpl.builder()
+                .ordered(false)
+                .deliverSubject(deliverSubject)
+                .flowControl(Optional.empty())
+                .idleHeartbeat(Optional.of(Duration.ofMillis(750)))
+                .rateLimit(Optional.empty())
+                .headersOnly(Optional.empty())
+                .deliverGroup(Optional.empty())
+                .build();
+        client.addConsumerIfAbsent(consumerConfiguration, pushConfiguration)
+                .chain(() -> {
+                    replyCancellable = client.subscribe(consumerConfiguration, pushConfiguration, newReplyListener())
+                            .subscribe().with(unused -> {
+                                // replies are handled by the listener; items reaching here have already been dispatched
+                            }, this::onSubscriptionFailure);
+                    active = true;
+                    return Uni.createFrom().voidItem();
+                })
+                .subscribe()
+                .with(unused -> future.complete(null), failure -> {
+                    onInitFailure(failure);
+                    future.completeExceptionally(new JetStreamRequestSubscriptionException(channelName, replySubject, failure));
+                });
+    }
+
+    private ConsumerListener<Rep> newReplyListener() {
+        return new ConsumerListener<>() {
+            @Override
+            public void onMessage(Message<Rep> message) {
+                onReply(message);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                onSubscriptionFailure(throwable);
+            }
+        };
+    }
+
+    private void onInitFailure(final Throwable failure) {
+        log.errorf(failure,
+                "JetStream request/reply consumer for channel '%s' could not be started; it will retry on the next request",
+                channelName);
+        resetSubscription();
+    }
+
+    private synchronized void onSubscriptionFailure(final Throwable failure) {
+        log.warnf(failure,
+                "JetStream request/reply reply consumer for channel '%s' failed; it will restart on the next request",
+                channelName);
+        resetSubscription();
+    }
+
+    private void resetSubscription() {
+        active = false;
+        final var cancellable = replyCancellable;
+        if (cancellable != null) {
+            try {
+                cancellable.cancel();
+            } catch (RuntimeException ignored) {
+                // best effort only
+            }
+        }
+        replyCancellable = null;
+    }
+
+    private void onReply(final Message<?> message) {
+        final Optional<String> correlationId = firstHeader(message, JetStreamRequestReply.CORRELATION_ID_HEADER)
+                .flatMap(correlationIdHandler::parse);
+        try {
+            if (correlationId.isEmpty() || !pendingReplies.containsKey(correlationId.get())) {
+                log.debugf("Dropping unmatched reply with subject '%s'", firstHeader(message, "subject").orElse("?"));
+                return;
+            }
+            final var pending = pendingReplies.get(correlationId.get());
+            if (pending != null && !pending.isDone()) {
+                final Object payload = message.getPayload();
+                final Optional<Throwable> businessFailure = failureHandler == null ? Optional.empty()
+                        : failureHandler.failure(payload);
+                if (businessFailure.isPresent()) {
+                    pending.fail(businessFailure.get());
+                } else {
+                    @SuppressWarnings("unchecked")
+                    final Message<Rep> typedReply = (Message<Rep>) message;
+                    pending.complete(typedReply);
+                }
+            }
+        } finally {
+            ackQuietly(message);
+        }
+    }
+
+    private <M extends Message<? extends Req>> M withCorrelationId(final M message, final String correlationId) {
+        final var existing = message.getMetadata().get(PublishMessageMetadata.class);
+        final var headers = new HashMap<>(existing.map(PublishMessageMetadata::headers).orElseGet(Map::of));
+        headers.put(JetStreamRequestReply.CORRELATION_ID_HEADER, List.of(correlationId));
+        headers.put(JetStreamRequestReply.REPLY_SUBJECT_HEADER, List.of(replySubject));
+        final var metadata = existing.map(pm -> new PublishMessageMetadata(
+                pm.stream(),
+                pm.subject(),
+                pm.messageId(),
+                pm.payload(),
+                headers,
+                pm.sequence())).orElseGet(() -> new PublishMessageMetadata(
+                        stream,
+                        null,
+                        null,
+                        null,
+                        headers,
+                        null));
+        final var newMetadata = message.getMetadata().without(PublishMessageMetadata.class).with(metadata);
+        return (M) message.withMetadata(newMetadata);
+    }
+
+    private static Optional<String> firstHeader(final Message<?> message, final String headerName) {
+        return Optional.ofNullable(message)
+                .map(Message::getMetadata)
+                .flatMap(metadata -> metadata.get(SubscribeMessageMetadata.class))
+                .map(subscribeMetadata -> subscribeMetadata.headers().get(headerName))
+                .filter(values -> !values.isEmpty())
+                .map(values -> values.get(0));
+    }
+
+    private static void ackQuietly(final Message<?> message) {
+        try {
+            final var future = message.ack();
+            if (future != null) {
+                // non-blocking: the reply listener runs on a Vert.x event loop and must not be parked here
+                future.toCompletableFuture().whenComplete((unused, failure) -> {
+                    if (failure != null) {
+                        log.debugf(failure, "Failed to acknowledge reply message");
+                    }
+                });
+            }
+        } catch (RuntimeException e) {
+            log.debugf(e, "Failed to start acknowledging reply message");
+        }
+    }
+
+    private static <T> T resolveHandler(final Instance<T> candidates, final Class<T> type, final String channelName,
+            final String attribute, final String id) {
+        try {
+            return CDIUtils.getInstanceById(candidates, id).get();
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                    "No " + type.getSimpleName() + " with id '" + id + "' found for channel '" + channelName
+                            + "'. Define a CDI bean annotated with @Identifier(\"" + id + "\") or set '" + attribute
+                            + "' to an available handler id.",
+                    e);
+        }
+    }
+
+    private static Optional<String> nonBlank(final Optional<String> value) {
+        return value.map(String::trim).filter(s -> !s.isEmpty());
+    }
+
+    private static String requiredConfig(final Config mpConfig, final String key, final String channelName) {
+        try {
+            return requireNonNull(mpConfig.getOptionalValue(key, String.class).orElse(null),
+                    "channel '" + channelName + "' requires a '" + key + "' connector attribute");
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("channel '" + channelName + "' requires a '" + key + "' connector attribute", e);
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestReplyProducer.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Typed;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.providers.extension.ChannelProducer;
+
+/**
+ * Resolves {@code @Channel} injections of {@link JetStreamRequestReply}. The channel name is read from the injection
+ * point at runtime (the {@link Channel#value()} member is non-binding), mirroring how SmallRye resolves standard
+ * emitters.
+ */
+@ApplicationScoped
+public class JetStreamRequestReplyProducer {
+
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @SuppressWarnings("unchecked")
+    @Produces
+    @Typed(JetStreamRequestReply.class)
+    @Channel("") // Stream name is ignored during type-safe resolution
+    <Req, Rep> JetStreamRequestReply<Req, Rep> produce(InjectionPoint injectionPoint) {
+        String channelName = ChannelProducer.getChannelName(injectionPoint);
+        JetStreamRequestReply<Req, Rep> emitter = (JetStreamRequestReply<Req, Rep>) channelRegistry
+                .getEmitter(channelName, JetStreamRequestReply.class);
+        if (emitter == null) {
+            throw new IllegalStateException(
+                    "No JetStream request-reply emitter registered for channel '" + channelName
+                            + "'. Ensure the channel is configured with connector 'quarkus-jetstream' and a reply subject.");
+        }
+        return emitter;
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestShutdownException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestShutdownException.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+/**
+ * Raised when a {@link JetStreamRequestReply} instance is closed (application shutdown) while requests are still
+ * outstanding, or when a new request is made after the instance has been closed.
+ */
+public class JetStreamRequestShutdownException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public JetStreamRequestShutdownException(String channelName) {
+        super("JetStream request/reply emitter for channel '" + channelName + "' was shut down");
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestSubscriptionException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestSubscriptionException.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+/**
+ * Raised when the reply consumer cannot be created for a request/reply channel.
+ */
+public class JetStreamRequestSubscriptionException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private final String channelName;
+    private final String replySubject;
+
+    public JetStreamRequestSubscriptionException(String channelName, String replySubject, Throwable cause) {
+        super("Failed to create reply consumer for channel '" + channelName + "' on subject '" + replySubject + "'", cause);
+        this.channelName = channelName;
+        this.replySubject = replySubject;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public String getReplySubject() {
+        return replySubject;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestTimeoutException.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/JetStreamRequestTimeoutException.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+/**
+ * Raised when a {@link JetStreamRequestReply#request(Object)} call does not receive its reply within the configured
+ * timeout ({@code reply.timeout} connector attribute, default 5000 ms). The correlation id of the outstanding request is
+ * preserved for diagnostics.
+ */
+public class JetStreamRequestTimeoutException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private final String correlationId;
+
+    public JetStreamRequestTimeoutException(String correlationId, long timeoutMillis) {
+        super("No reply received within " + timeoutMillis + " ms for correlation id '" + correlationId + "'");
+        this.correlationId = correlationId;
+    }
+
+    /** @return the correlation id of the request that timed out */
+    public String getCorrelationId() {
+        return correlationId;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/PendingReply.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/PendingReply.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * A request that has been published and is waiting for its matching reply. Instances are exposed read-only through
+ * {@link JetStreamRequestReply#getPendingReplies()}.
+ */
+public final class PendingReply {
+    private final String correlationId;
+    private final Instant createdAt;
+    private final CompletableFuture<Message<?>> future = new CompletableFuture<>();
+
+    public PendingReply(String correlationId, Instant createdAt) {
+        this.correlationId = correlationId;
+        this.createdAt = createdAt;
+    }
+
+    /** The correlation id this request was published with. */
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    /** The instant the request was registered as pending. */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    boolean isDone() {
+        return future.isDone();
+    }
+
+    void complete(Message<?> reply) {
+        future.complete(reply);
+    }
+
+    void fail(Throwable cause) {
+        future.completeExceptionally(cause);
+    }
+
+    CompletableFuture<Message<?>> future() {
+        return future;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/ReplyFailureHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/ReplyFailureHandler.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.util.Optional;
+
+/**
+ * Strategy for deciding whether an incoming reply payload represents a business failure that should fail the caller's
+ * {@link Uni}, or a normal response. Provide an implementation as a CDI bean (for example one reading a status field from
+ * a JSON error body) and select it per channel with the {@code reply.failure.handler} connector attribute; when none is
+ * configured, every matched reply completes the call normally.
+ */
+public interface ReplyFailureHandler {
+
+    /**
+     * @param payload the deserialized reply payload
+     * @return an empty {@link Optional} if this is a successful response, or the failure to propagate to the caller
+     */
+    Optional<Throwable> failure(Object payload);
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/UuidCorrelationIdHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/UuidCorrelationIdHandler.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.smallrye.common.annotation.Identifier;
+
+/**
+ * The default {@link CorrelationIdHandler}: generates random version-4 UUIDs and validates incoming values as UUIDs.
+ */
+@ApplicationScoped
+@Identifier("uuid")
+public class UuidCorrelationIdHandler implements CorrelationIdHandler {
+
+    public static final String ID = "uuid";
+
+    private static final Pattern UUID_PATTERN = Pattern
+            .compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public Optional<String> parse(String value) {
+        if (value == null || !UUID_PATTERN.matcher(value).matches()) {
+            return Optional.empty();
+        }
+        try {
+            UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        return Optional.of(value.toLowerCase());
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/UuidCorrelationIdHandlerTest.java
+++ b/runtime/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/reply/UuidCorrelationIdHandlerTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.reply;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class UuidCorrelationIdHandlerTest {
+
+    private final UuidCorrelationIdHandler handler = new UuidCorrelationIdHandler();
+
+    @Test
+    void generatedIdsParseBack() {
+        for (int i = 0; i < 10; i++) {
+            final var generated = handler.generate();
+            assertThat(UUID.fromString(generated)).isNotNull();
+            assertThat(handler.parse(generated)).contains(generated);
+        }
+    }
+
+    @Test
+    void parseIsCaseInsensitive() {
+        final var id = UUID.randomUUID().toString();
+        assertThat(handler.parse(id.toUpperCase())).contains(id.toLowerCase());
+    }
+
+    @Test
+    void parseRejectsMalformedValues() {
+        assertThat(handler.parse(null)).isEmpty();
+        assertThat(handler.parse("")).isEmpty();
+        assertThat(handler.parse("not-a-uuid")).isEmpty();
+        assertThat(handler.parse("12345678-1234-1234-1234-1234567890a")).isEmpty();
+        assertThat(handler.parse("12345678-1234-1234-1234-zz34567890ab")).isEmpty();
+    }
+
+    @Test
+    void generatedIdsAreUnique() {
+        assertThat(handler.generate()).isNotEqualTo(handler.generate());
+    }
+
+}


### PR DESCRIPTION
# Add request/reply support (`JetStreamRequestReply`)

Adds request/reply semantics on top of the existing JetStream pub/sub connector.

> **Inspiration:** this feature mirrors SmallRye Reactive Messaging's **Kafka** `KafkaRequestReply` — the same shared-reply + correlation-ID-demotion model, adapted from Kafka topics to NATS JetStream subjects/streams.

## What it does
- New injectable emitter `JetStreamRequestReply<Req, Rep>` (via `@Channel`). Each `request(payload)` publishes to the channel subject and returns a `Uni` that completes with the correlation-matched reply, or fails on timeout.
- Replier stays a plain `@Incoming @Outgoing` method — the connector auto-routes the reply using the requestor's advertised reply subject and echoes the correlation ID (exactly how the Kafka sink reads `REPLY_TOPIC`/`REPLY_CORRELATION_ID`).
- Per-instance **non-durable** reply consumer on a shared reply subject (`deliver_policy=new`, `max_deliver=1`) with NATS `inactive_threshold` reclamation. Replies are demultiplexed by correlation ID and non-matches ack'd + discarded, so requestors/repliers scale independently with no instance identity to manage.

## Configuration (outgoing channel)
| Attribute | Description | Default |
|---|---|---|
| `reply.subject` | Subject replies are expected on | `<subject>.replies` |
| `reply.timeout` | Max wait for a reply (ms) | `5000` |
| `reply.inactive-threshold` | Idle-consumer reclaim (ms) | `60000` |
| `reply.correlation-id.handler` | `@Identifier` of a `CorrelationIdHandler` bean | `uuid` |
| `reply.failure.handler` | `@Identifier` of a `ReplyFailureHandler` bean | — |

## Pluggability & observability
- Custom `CorrelationIdHandler` (default UUID) and `ReplyFailureHandler` for error propagation.
- `getPendingReplies()` snapshot of in-flight requests; entries are cleaned up on complete / fail / timeout / shutdown.

## Error model
| Situation | Exception |
|---|---|
| No reply within `reply.timeout` | `JetStreamRequestTimeoutException` |
| Publish fails | `JetStreamRequestPublishException` |
| Stream missing at request time | `JetStreamRequestSubscriptionException` (re-subscribes on next request) |
| Shutdown while in-flight | `JetStreamRequestShutdownException` |

> Note: the stream must cover **both** the request and reply subjects. If the reply subject isn't covered, NATS still accepts the consumer but no reply can ever arrive, so requests fail with a timeout (verified against NATS 2.14).

## Tests
- **7 integration tests** (`ReplyTest`, deployment): round-trip; two requestors each receiving only their own reply; timeout + late-reply drop; publish-failure propagation; failure-handler + pending lifecycle; re-subscribe after stream failure; late-covered reply subject.
- **4 unit tests** for the UUID correlation handler (runtime).
- Full deployment suite: **49/49 green**; full build passes.