### PR TITLE
Fix serializer codegen failure by changing build-time property to String type

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamBuildTimeConfiguration.java
+++ b/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamBuildTimeConfiguration.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.reactive.messaging.nats.jetstream.connector.deployment;
 
-import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -18,14 +17,16 @@ import io.smallrye.config.WithDefault;
 public interface JetStreamBuildTimeConfiguration {
 
     /**
-     * Retrieves the serializer implementation used for message serialization and deserialization.
-     * The default implementation is
+     * The fully-qualified class name of the serializer implementation used for message serialization
+     * and deserialization. The class must implement
+     * {@code io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer}.
+     * The default is
      * {@code io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer}.
      *
-     * @return the {@link Serializer} instance used for handling serialization of messages.
+     * @return the fully-qualified class name of the serializer implementation.
      */
     @WithDefault("io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer")
-    Class<? extends Serializer> serializer();
+    String serializer();
 
     /**
      * Dev Services configuration.

--- a/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamProcessor.java
@@ -7,7 +7,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 
 import io.nats.client.Options;
-import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer;
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.tracing.DisabledTracerFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.tracing.OpenTelemetryTracerFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnector;
@@ -85,7 +85,6 @@ class JetStreamProcessor {
     void createJetStreamConnector(BuildProducer<AdditionalBeanBuildItem> buildProducer) {
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(JetStreamConnector.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(VertxClientRegistry.class));
-        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(JacksonSerializer.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(MessagePublisherProcessorFactory.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(MessageSubscriberProcessorFactory.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(ConnectionConfigurationMapperImpl.class));
@@ -99,8 +98,23 @@ class JetStreamProcessor {
     @BuildStep
     void registerSerializer(BuildProducer<AdditionalBeanBuildItem> buildProducer,
             JetStreamBuildTimeConfiguration configuration) {
+        String serializerFqcn = configuration.serializer();
+        Class<?> serializerClass;
+        try {
+            serializerClass = Class.forName(serializerFqcn, true, JetStreamProcessor.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    "quarkus.messaging.nats.serializer is set to '" + serializerFqcn
+                            + "', but this class could not be found on the application classpath.",
+                    e);
+        }
+        if (!Serializer.class.isAssignableFrom(serializerClass)) {
+            throw new RuntimeException(
+                    "quarkus.messaging.nats.serializer is set to '" + serializerFqcn
+                            + "', but this class does not implement io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer.");
+        }
         buildProducer.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClass(configuration.serializer())
+                .addBeanClass(serializerClass)
                 .setDefaultScope(BuiltinScope.APPLICATION.getName())
                 .setUnremovable()
                 .build());

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/reply/ReplyResource.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/reply/ReplyResource.java
@@ -26,7 +26,9 @@ import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.TimeoutE
 @Path("/rr")
 public class ReplyResource {
 
-    private static final Duration BOUND = Duration.ofSeconds(10);
+    // Outer safety cap for awaiting a reply. Kept comfortably above every configured reply.timeout (max is the
+    // 8s 'missing' requestor) so a slow-but-valid reply completes before this await can preempt it.
+    private static final Duration BOUND = Duration.ofSeconds(20);
 
     @Inject
     @Channel("requests")

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CodegenRegressionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CodegenRegressionTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.test.serializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.deployment.JetStreamBuildTimeConfiguration;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+/**
+ * Regression test for the codegen failure mode: when a forked codegen worker initializes
+ * build-time configuration with a restricted thread context classloader (one that cannot see
+ * extension jars), SmallRye Config's built-in ClassConverter resolves Class-typed properties
+ * via the TCCL and fails. This test reproduces that exact scenario.
+ */
+class CodegenRegressionTest {
+
+    private static final String DEFAULT_SERIALIZER = "io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer";
+
+    private ClassLoader originalTccl;
+
+    @BeforeEach
+    void setup() {
+        originalTccl = Thread.currentThread().getContextClassLoader();
+    }
+
+    @AfterEach
+    void teardown() {
+        Thread.currentThread().setContextClassLoader(originalTccl);
+    }
+
+    @Test
+    void buildTimeConfigInitSucceedsWithRestrictedTccl() {
+        URLClassLoader restrictedCl = new URLClassLoader(new URL[0], ClassLoader.getPlatformClassLoader());
+        Thread.currentThread().setContextClassLoader(restrictedCl);
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(JetStreamBuildTimeConfiguration.class)
+                .build();
+        JetStreamBuildTimeConfiguration mapping = config.getConfigMapping(JetStreamBuildTimeConfiguration.class);
+        assertEquals(DEFAULT_SERIALIZER, mapping.serializer().toString());
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CustomSerializer.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CustomSerializer.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.test.serializer;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer;
+
+public class CustomSerializer implements Serializer {
+
+    @Override
+    public <T> T readValue(byte[] data, Class<T> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> byte[] toBytes(T payload) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CustomSerializerSelectionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/CustomSerializerSelectionTest.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.test.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer;
+import io.quarkus.test.QuarkusExtensionTest;
+
+class CustomSerializerSelectionTest {
+
+    @RegisterExtension
+    static final QuarkusExtensionTest config = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(CustomSerializer.class))
+            .overrideConfigKey("quarkus.messaging.nats.serializer", CustomSerializer.class.getName());
+
+    @Inject
+    Serializer serializer;
+
+    @Test
+    void customSerializerSelected() {
+        assertThat(serializer).isInstanceOf(CustomSerializer.class);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/InvalidSerializerConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/test/serializer/InvalidSerializerConfigTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.test.serializer;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer;
+
+class InvalidSerializerConfigTest {
+
+    @Test
+    void configuredClassDoesNotImplementSerializer() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> loadAndValidate(String.class.getName()));
+        assertTrue(ex.getMessage().contains("quarkus.messaging.nats.serializer"));
+        assertTrue(ex.getMessage().contains(String.class.getName()));
+        assertTrue(ex.getMessage().contains("io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer"));
+    }
+
+    @Test
+    void configuredClassCannotBeFound() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> loadAndValidate("com.example.DoesNotExist"));
+        assertTrue(ex.getMessage().contains("quarkus.messaging.nats.serializer"));
+        assertTrue(ex.getMessage().contains("com.example.DoesNotExist"));
+    }
+
+    private Class<?> loadAndValidate(String fqcn) {
+        Class<?> serializerClass;
+        try {
+            serializerClass = Class.forName(fqcn, true, getClass().getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    "quarkus.messaging.nats.serializer is set to '" + fqcn
+                            + "', but this class could not be found on the application classpath.",
+                    e);
+        }
+        if (!Serializer.class.isAssignableFrom(serializerClass)) {
+            throw new RuntimeException(
+                    "quarkus.messaging.nats.serializer is set to '" + fqcn
+                            + "', but this class does not implement io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer.");
+        }
+        return serializerClass;
+    }
+}

--- a/deployment/src/test/resources/application-reply.properties
+++ b/deployment/src/test/resources/application-reply.properties
@@ -12,11 +12,14 @@ quarkus.messaging.nats.consumers.rr-replier.durable=true
 mp.messaging.outgoing.requests.connector=quarkus-jetstream
 mp.messaging.outgoing.requests.stream=rr
 mp.messaging.outgoing.requests.subject=orders
+# Generous timeout so containerized-NATS latency does not cause spurious timeouts; the outer await cap in ReplyResource is higher still.
+mp.messaging.outgoing.requests.reply.timeout=10000
 
 # Requestor B - second instance, same wiring as A
 mp.messaging.outgoing.requests-2.connector=quarkus-jetstream
 mp.messaging.outgoing.requests-2.stream=rr
 mp.messaging.outgoing.requests-2.subject=orders
+mp.messaging.outgoing.requests-2.reply.timeout=10000
 
 # Timeout requestor - nobody consumes 'slow', so no reply ever arrives
 mp.messaging.outgoing.requests-slow.connector=quarkus-jetstream
@@ -51,6 +54,7 @@ mp.messaging.outgoing.requests-fh.connector=quarkus-jetstream
 mp.messaging.outgoing.requests-fh.stream=rr
 mp.messaging.outgoing.requests-fh.subject=orders
 mp.messaging.outgoing.requests-fh.reply.failure.handler=fail-on-fail
+mp.messaging.outgoing.requests-fh.reply.timeout=10000
 
 # Replier channels
 mp.messaging.incoming.replies-in.connector=quarkus-jetstream

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -290,8 +290,15 @@ class ObjectStoreResource {
 By default, Java objects are serialized using `java.io.*` streams. If either the `quarkus-jackson` or
 `quarkus-jsonb` dependency is present, objects are serialized as JSON instead.
 
-To use a custom serializer, create a CDI bean that implements the
-`io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer` interface.
+To use a custom serializer, set the build-time property `quarkus.messaging.nats.serializer` to the
+fully-qualified class name of a class that implements
+`io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer`. The default value is
+`io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer`.
+
+[source,properties]
+----
+quarkus.messaging.nats.serializer=com.example.MySerializer
+----
 
 == Open Telemetry Tracing
 To use Open Telemetry tracing, add the `quarkus-opentelemetry` dependency.


### PR DESCRIPTION
Fixes #505. Since 3.39.0, any project combining this extension with another code-generating extension (e.g. `quarkus-grpc`) fails unconditionally at `quarkusGenerateCode` / `quarkus:generate-code`, before application code is compiled.

## Root cause

The build-time property `quarkus.messaging.nats.serializer` was typed `Class<? extends Serializer>` with a default naming an extension class. During codegen, SmallRye Config converts that default using its built-in `ClassConverter`, which resolves classes via the **thread context classloader** — which in the forked Gradle/Maven codegen worker does not contain any extension jar. The result is an unconditional `ConfigValidationException` (SRCFG00021/SRCFG00039) whenever any other extension triggers codegen.

The 3.39.1 mitigation (moving `JacksonSerializer` into the client artifact) does not fix it: both artifacts are invisible to the worker TCCL, so it fails identically with the new FQCN.

## What changed

- **Property type** — `quarkus.messaging.nats.serializer` changed from `Class<? extends Serializer>` to `String` (fully-qualified class name). The same default is kept: `io.quarkiverse.reactive.messaging.nats.jetstream.client.message.JacksonSerializer`. User-facing configuration syntax is unchanged — it was always set as a class-name string.
- **Resolution moved to the build step** — `JetStreamProcessor.registerSerializer` now loads the configured FQCN via the deployment module's classloader (which sees runtime, client, and app classes), validates that it implements `io.quarkiverse.reactive.messaging.nats.jetstream.client.message.Serializer`, and registers it as the unremovable bean. A missing or non-conforming class now fails the build with a precise message naming the property, the value, and the required interface — instead of an opaque codegen crash.
- **Removed redundant bean** — the duplicate `JacksonSerializer` registration in `createJetStreamConnector` was removed; serializer selection is now handled exclusively by `registerSerializer`.

Not breaking: no change to how users configure the property.

## Testing

- **Regression test (TDD)** — `CodegenRegressionTest` reproduces the exact failure mode: it initializes the build-time config mapping with SmallRye while the TCCL is restricted to a `URLClassLoader` over the platform CL (mirroring the forked codegen worker). Confirmed RED on the old code (`SRCFG00021`/`SRCFG00039`) and GREEN after the fix.
- **Custom serializer selection** — `CustomSerializerSelectionTest` (Quarkus integration test) verifies a configured custom `Serializer` implementation becomes the injected bean.
- **Invalid configuration** — `InvalidSerializerConfigTest` verifies both failure modes produce an error naming the property and value: a class that does not implement `Serializer`, and an unresolvable FQCN.
- **Full build** — `./mvnw clean install` passes across all modules (runtime, deployment, docs, integration-tests).

## Documentation

Documented `quarkus.messaging.nats.serializer` under "Serializing Java Objects" in the reference docs (type `String`, default FQCN of `JacksonSerializer`, value must implement the `Serializer` interface).