### PR TITLE
Refactor channel configuration design

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/deployment/JetStreamProcessor.java
@@ -14,8 +14,9 @@ import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConne
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ConnectionConfigurationMapperImpl;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.TlsContextFactoryImpl;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.VertxClientRegistry;
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ChannelConfigurationFactoryImpl;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ConsumerChannelConfigurationFactoryImpl;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.JetStreamRecorder;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.PublisherChannelConfigurationFactoryImpl;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.publisher.MessagePublisherProcessorFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.subscriber.MessageSubscriberProcessorFactory;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.RequestReplyFactory;
@@ -92,7 +93,8 @@ class JetStreamProcessor {
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(RequestReplyFactory.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(RequestReplyProducer.class));
         buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(UuidCorrelationIdHandler.class));
-        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(ChannelConfigurationFactoryImpl.class));
+        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(PublisherChannelConfigurationFactoryImpl.class));
+        buildProducer.produce(AdditionalBeanBuildItem.unremovableOf(ConsumerChannelConfigurationFactoryImpl.class));
     }
 
     @BuildStep

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/JetStreamConnector.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/JetStreamConnector.java
@@ -31,7 +31,7 @@ import io.smallrye.reactive.messaging.health.HealthReporter;
 @ConnectorAttribute(name = "payload-type", description = "The payload type", direction = INCOMING, type = "String")
 @ConnectorAttribute(name = "batch-size", description = "The batch size", direction = INCOMING, type = "Integer", defaultValue = "100")
 @ConnectorAttribute(name = "timeout", description = "The timeout in milliseconds for pulling messages", direction = INCOMING, type = "Long", defaultValue = "1000")
-@ConnectorAttribute(name = "retry-backoff", description = "The retry backoff in milliseconds for retry processing messages", direction = INCOMING_AND_OUTGOING, type = "Long", defaultValue = "10000")
+@ConnectorAttribute(name = "retry-backoff", description = "The retry backoff in milliseconds for retry processing messages", direction = INCOMING_AND_OUTGOING, type = "Long")
 @ConnectorAttribute(name = "datasource", description = "The name of the datasource", direction = INCOMING_AND_OUTGOING, type = "String")
 @ConnectorAttribute(name = "reply.subject", description = "The subject on which replies are expected when using JetStreamRequestReply. Defaults to the channel subject with '.replies' appended.", direction = OUTGOING, type = "String")
 @ConnectorAttribute(name = "reply.timeout", description = "How long to wait for a reply in milliseconds when using JetStreamRequestReply", direction = OUTGOING, type = "Long", defaultValue = "5000")
@@ -55,16 +55,14 @@ public class JetStreamConnector implements InboundConnector, OutboundConnector, 
     @SuppressWarnings("ReactiveStreamsUnusedPublisher")
     @Override
     public Flow.Publisher<? extends Message<?>> getPublisher(Config config) {
-        final var configuration = new JetStreamConnectorIncomingConfiguration(config);
-        final var processor = messagePublisherProcessorFactory.create(configuration);
+        final var processor = messagePublisherProcessorFactory.create(config);
         processors.add(processor);
         return processor.publisher();
     }
 
     @Override
     public Flow.Subscriber<? extends Message<?>> getSubscriber(Config config) {
-        final var configuration = new JetStreamConnectorOutgoingConfiguration(config);
-        final var processor = messageSubscriberProcessorFactory.create(configuration);
+        final var processor = messageSubscriberProcessorFactory.create(config);
         processors.add(processor);
         return processor.subscriber();
     }
@@ -73,7 +71,7 @@ public class JetStreamConnector implements InboundConnector, OutboundConnector, 
     public HealthReport getReadiness() {
         final HealthReport.HealthReportBuilder builder = HealthReport.builder();
         processors.forEach(processor -> builder.add(new HealthReport.ChannelInfo(
-                processor.channel(),
+                processor.channelConfiguration().name(),
                 processor.health().healthy(),
                 processor.health().message())));
         return builder.build();
@@ -83,7 +81,7 @@ public class JetStreamConnector implements InboundConnector, OutboundConnector, 
     public HealthReport getLiveness() {
         final HealthReport.HealthReportBuilder builder = HealthReport.builder();
         processors.forEach(processor -> builder.add(new HealthReport.ChannelInfo(
-                processor.channel(),
+                processor.channelConfiguration().name(),
                 processor.health().healthy(),
                 processor.health().message())));
         return builder.build();

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ChannelConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ChannelConfiguration.java
@@ -5,17 +5,58 @@ import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
 
+/**
+ * Represents the configuration for a channel, defining key properties that
+ * are used to interact with a data stream or datasource. A channel configuration
+ * represents the common settings required for both producers and consumers
+ * communicating via a streaming platform or messaging system.
+ */
 public interface ChannelConfiguration {
 
+    /**
+     * Retrieves the name of the channel configuration.
+     *
+     * @return the name of the channel as a non-null String
+     */
     @NonNull
     String name();
 
+    /**
+     * Retrieves the name of the stream associated with the channel configuration.
+     *
+     * @return the name of the stream as a non-null String
+     */
     @NonNull
     String stream();
 
+    /**
+     * Retrieves the retry backoff duration for the channel configuration, if specified.
+     * The retry backoff duration indicates the time interval to wait before retrying
+     * an operation after a failure.
+     *
+     * @return the retry backoff duration as a {@code Duration}
+     */
     @NonNull
     Optional<Duration> retryBackoff();
 
+    /**
+     * Retrieves the name of the datasource associated with the channel configuration.
+     *
+     * @return the name of the datasource as a non-null String
+     */
     @NonNull
     String datasource();
+
+    /**
+     * Retrieves the retry backoff duration configured for the channel.
+     * The retry backoff duration specifies the time interval to wait before retrying
+     * an operation after a failure. If no retry backoff is defined, this method
+     * throws an {@code IllegalArgumentException}.
+     *
+     * @return the retry backoff duration as a non-null {@code Duration}
+     * @throws IllegalArgumentException if the retry backoff duration is not defined
+     */
+    default @NonNull Duration getRetryBackoff() {
+        return retryBackoff().orElse(Duration.ofMillis(10000));
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ChannelConfigurationFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ChannelConfigurationFactory.java
@@ -1,9 +1,0 @@
-package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration;
-
-import org.eclipse.microprofile.config.Config;
-
-public interface ChannelConfigurationFactory {
-
-    PublisherChannelConfiguration create(String channel, Config config);
-
-}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfiguration.java
@@ -5,18 +5,62 @@ import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
 
+/**
+ * Represents the configuration of a consumer channel. This interface extends
+ * {@link ChannelConfiguration} and defines additional configurations specific
+ * to a consumer, enabling properties related to processing messages from a
+ * stream or datasource.
+ */
 public interface ConsumerChannelConfiguration extends ChannelConfiguration {
 
+    /**
+     * Retrieves the name of the consumer associated with the consumer channel configuration.
+     *
+     * @return the name of the consumer as a non-null String
+     */
     @NonNull
-    String consumer();
+    Optional<String> consumer();
 
+    /**
+     * Retrieves the specific payload type expected by the consumer channel.
+     * The payload type indicates the class that represents the structure of the
+     * messages the consumer expects to process. If no explicit type is configured,
+     * an empty {@code Optional} is returned.
+     *
+     * @return an {@code Optional} containing the payload type as a {@code Class<?>}, or empty if unspecified.
+     */
     @NonNull
-    Optional<Class<?>> payloadType();
+    <T> Optional<Class<T>> payloadType();
 
+    /**
+     * Retrieves the batch size configuration for the consumer channel.
+     * The batch size specifies the maximum number of messages that can
+     * be processed in a single batch.
+     *
+     * @return the batch size as a non-null Integer
+     */
     @NonNull
     Integer batchSize();
 
+    /**
+     * Retrieves the timeout duration for the consumer channel.
+     * The timeout specifies the maximum amount of time the consumer
+     * will wait for messages or a response during processing.
+     *
+     * @return the timeout duration as a non-null {@code Duration}
+     */
     @NonNull
     Duration timeout();
 
+    /**
+     * Retrieves the name of the consumer associated with the current consumer channel configuration.
+     * If the consumer name is not configured, this method will throw an {@code IllegalArgumentException}.
+     *
+     * @return the name of the consumer as a non-null String
+     * @throws IllegalArgumentException if the consumer name is missing
+     */
+    default @NonNull String getConsumer() {
+        return consumer()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Missing consumer for channel: %s", name())));
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactory.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration;
+
+import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * A factory interface for creating instances of {@link ConsumerChannelConfiguration}.
+ * This interface provides a method to initialize a {@link ConsumerChannelConfiguration}
+ * using a specified {@link Config} object, allowing for the customization and
+ * configuration of consumer channels.
+ */
+public interface ConsumerChannelConfigurationFactory {
+
+    /**
+     * Creates a new instance of {@link ConsumerChannelConfiguration} using the provided
+     * configuration settings.
+     *
+     * @param config the {@link Config} object containing the configuration properties
+     *        required to create a {@link ConsumerChannelConfiguration}
+     * @return a new {@link ConsumerChannelConfiguration} instance initialized with the
+     *         specified configuration
+     */
+    @NonNull
+    ConsumerChannelConfiguration create(@NonNull Config config);
+
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactoryImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactoryImpl.java
@@ -18,7 +18,9 @@ public class ConsumerChannelConfigurationFactoryImpl implements ConsumerChannelC
         final var channelConfig = new JetStreamConnectorIncomingConfiguration(config);
         return ConsumerChannelConfigurationImpl.builder()
                 .name(channelConfig.getChannel())
-                .stream(channelConfig.getStream().orElseThrow(() -> new IllegalArgumentException(String.format("Missing stream for channel: %s", channelConfig.getChannel()))))
+                .stream(channelConfig.getStream()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                String.format("Missing stream for channel: %s", channelConfig.getChannel()))))
                 .retryBackoff(channelConfig.getRetryBackoff().map(Duration::ofMillis))
                 .datasource(channelConfig.getDatasource().orElse(ClientRegistry.DEFAULT_CLIENT_NAME))
                 .consumer(channelConfig.getConsumer())

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactoryImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationFactoryImpl.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.NonNull;
+
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnectorIncomingConfiguration;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
+
+@ApplicationScoped
+public class ConsumerChannelConfigurationFactoryImpl implements ConsumerChannelConfigurationFactory {
+
+    @Override
+    public @NonNull ConsumerChannelConfiguration create(@NonNull Config config) {
+        final var channelConfig = new JetStreamConnectorIncomingConfiguration(config);
+        return ConsumerChannelConfigurationImpl.builder()
+                .name(channelConfig.getChannel())
+                .stream(channelConfig.getStream().orElseThrow(() -> new IllegalArgumentException(String.format("Missing stream for channel: %s", channelConfig.getChannel()))))
+                .retryBackoff(channelConfig.getRetryBackoff().map(Duration::ofMillis))
+                .datasource(channelConfig.getDatasource().orElse(ClientRegistry.DEFAULT_CLIENT_NAME))
+                .consumer(channelConfig.getConsumer())
+                .batchSize(channelConfig.getBatchSize())
+                .timeout(Duration.ofMillis(channelConfig.getTimeout()))
+                .payloadType(channelConfig.getPayloadType().map(this::loadClass))
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Class<T> loadClass(String type) {
+        try {
+            final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            return (Class<T>) classLoader.loadClass(type);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/ConsumerChannelConfigurationImpl.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.jspecify.annotations.NonNull;
+
+import lombok.Builder;
+
+@Builder
+public record ConsumerChannelConfigurationImpl(@NonNull String name,
+        @NonNull String stream,
+        @NonNull Optional<Duration> retryBackoff,
+        @NonNull String datasource,
+        @NonNull Optional<String> consumer,
+        @NonNull Optional<Class<?>> payloadType,
+        @NonNull Integer batchSize,
+        @NonNull Duration timeout) implements ConsumerChannelConfiguration {
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfiguration.java
@@ -10,21 +10,66 @@ import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.ReplyFai
 
 public interface PublisherChannelConfiguration extends ChannelConfiguration {
 
+    /**
+     * Retrieves the subject associated with the publisher channel configuration.
+     * This represents the target subject where messages will be published.
+     *
+     * @return a non-null string representing the subject
+     */
     @NonNull
     String subject();
 
+    /**
+     * Retrieves the optional reply subject associated with the publisher channel configuration.
+     * The reply subject determines where reply messages are directed for a given request-reply interaction.
+     *
+     * @return an optional string representing the reply subject, which will be non-empty
+     *         if a reply subject is configured, or empty if no reply subject is defined
+     */
     @NonNull
     Optional<String> replySubject();
 
+    /**
+     * Retrieves the optional reply timeout duration for the publisher channel configuration.
+     * The reply timeout determines the maximum time to wait for a reply in a request-reply interaction.
+     *
+     * @return an optional {@code Duration} representing the reply timeout. It will be non-empty if a timeout is configured,
+     *         or empty if no timeout is defined.
+     */
     @NonNull
     Optional<Duration> replyTimeout();
 
+    /**
+     * Retrieves the optional duration that defines the inactivity threshold
+     * for receiving replies in a publisher channel configuration. The inactivity
+     * threshold represents the duration after which a reply is considered inactive
+     * if no response is received.
+     *
+     * @return an optional {@code Duration} representing the inactivity threshold
+     *         for replies. The value will be non-empty if an inactivity threshold
+     *         is configured, or empty if no such threshold is defined.
+     */
     @NonNull
     Optional<Duration> replyInactiveThreshold();
 
+    /**
+     * Retrieves the {@code CorrelationIdHandler} associated with the publisher channel configuration.
+     * The {@code CorrelationIdHandler} is responsible for generating and parsing correlation IDs
+     * used to match requests with their corresponding replies in a request-reply interaction.
+     *
+     * @return a non-null {@code CorrelationIdHandler} instance
+     */
     @NonNull
     CorrelationIdHandler replyCorrelationIdHandler();
 
+    /**
+     * Retrieves the optional {@code ReplyFailureHandler} associated with the publisher channel configuration.
+     * The {@code ReplyFailureHandler} is responsible for determining whether an incoming reply payload
+     * represents a business failure that should result in a failure propagated to the caller, or a normal response.
+     *
+     * @return an {@code Optional} containing the {@code ReplyFailureHandler} if configured, or an empty {@code Optional}
+     *         if no failure handling strategy is defined.
+     */
     @NonNull
     Optional<ReplyFailureHandler> replyFailureHandler();
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactory.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration;
+
+import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Factory interface for creating instances of {@code PublisherChannelConfiguration}.
+ * This interface provides a method to construct a {@code PublisherChannelConfiguration}
+ * using a provided {@code Config} object.
+ */
+public interface PublisherChannelConfigurationFactory {
+
+    /**
+     * Creates a new instance of {@code PublisherChannelConfiguration} using the provided configuration.
+     *
+     * @param config the configuration object used to create the {@code PublisherChannelConfiguration}
+     * @return an instance of {@code PublisherChannelConfiguration} configured according to the provided {@code config}
+     */
+    @NonNull
+    PublisherChannelConfiguration create(@NonNull Config config);
+
+    /**
+     * Creates a new instance of {@code PublisherChannelConfiguration} using the provided name and configuration.
+     *
+     * @param name the name associated with the publisher channel configuration; must not be null
+     * @param config the configuration object used to create the {@code PublisherChannelConfiguration}; must not be null
+     * @return an instance of {@code PublisherChannelConfiguration} configured based on the provided parameters
+     */
+    @NonNull
+    PublisherChannelConfiguration create(@NonNull String name, @NonNull Config config);
+
+}

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactoryImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactoryImpl.java
@@ -3,33 +3,41 @@ package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration
 import java.time.Duration;
 import java.util.Optional;
 
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnector;
+import io.smallrye.reactive.messaging.providers.impl.Configs;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 
 import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.NonNull;
 
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnector;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnectorOutgoingConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.CorrelationIdHandler;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.ReplyFailureHandler;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.UuidCorrelationIdHandler;
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
-import io.smallrye.reactive.messaging.providers.impl.Configs;
 
 @ApplicationScoped
-public class ChannelConfigurationFactoryImpl implements ChannelConfigurationFactory {
+public class PublisherChannelConfigurationFactoryImpl implements PublisherChannelConfigurationFactory {
     private final Instance<CorrelationIdHandler> correlationIdHandlers;
     private final Instance<ReplyFailureHandler> failureHandlers;
 
-    public ChannelConfigurationFactoryImpl(@Any Instance<CorrelationIdHandler> correlationIdHandlers,
+    public PublisherChannelConfigurationFactoryImpl(@Any Instance<CorrelationIdHandler> correlationIdHandlers,
             @Any Instance<ReplyFailureHandler> failureHandlers) {
         this.correlationIdHandlers = correlationIdHandlers;
         this.failureHandlers = failureHandlers;
     }
 
     @Override
-    public PublisherChannelConfiguration create(String channel, Config config) {
+    public @NonNull PublisherChannelConfiguration create(@NonNull Config config) {
+        final var channelConfig = new JetStreamConnectorOutgoingConfiguration(config);
+        return create(channelConfig.getChannel(), channelConfig);
+    }
+
+    @Override
+    public @NonNull PublisherChannelConfiguration create(@NonNull String channel, @NonNull Config config) {
         final var channelConfig = Configs.outgoing(config, JetStreamConnector.CONNECTOR_NAME, channel);
         final var correlationIdHandlerId = nonBlank(
                 channelConfig.getOptionalValue("reply.correlation-id.handler", String.class))
@@ -50,6 +58,29 @@ public class ChannelConfigurationFactoryImpl implements ChannelConfigurationFact
                         "reply.correlation-id.handler", correlationIdHandlerId))
                 .replyFailureHandler(failureHandlerId.map(
                         id -> resolveHandler(failureHandlers, ReplyFailureHandler.class, channel, "reply.failure.handler", id)))
+                .build();
+    }
+
+    private PublisherChannelConfiguration create(@NonNull String name,
+            @NonNull JetStreamConnectorOutgoingConfiguration channelConfig) {
+        final var correlationIdHandlerId = channelConfig.getReplyCorrelationIdHandler()
+                .orElse(UuidCorrelationIdHandler.ID);
+        final var failureHandlerId = channelConfig.getReplyFailureHandler();
+        return PublisherChannelConfigurationImpl.builder()
+                .name(name)
+                .stream(channelConfig.getStream().orElseThrow(() -> new IllegalArgumentException(String.format("Missing stream for channel: %s", name))))
+                .retryBackoff(channelConfig.getRetryBackoff().map(Duration::ofMillis))
+                .datasource(channelConfig.getDatasource().orElse(ClientRegistry.DEFAULT_CLIENT_NAME))
+                .subject(channelConfig.getSubject().orElseThrow(() -> new IllegalArgumentException(String.format("Missing subject for channel: %s", name))))
+                .replySubject(channelConfig.getReplySubject())
+                .replyTimeout(Optional.of(Duration.ofMillis(channelConfig.getReplyTimeout())))
+                .replyInactiveThreshold(Optional.of(Duration.ofMillis(channelConfig.getReplyInactiveThreshold())))
+                .replyCorrelationIdHandler(
+                        resolveHandler(correlationIdHandlers, CorrelationIdHandler.class, name,
+                                "reply.correlation-id.handler", correlationIdHandlerId))
+                .replyFailureHandler(failureHandlerId.map(
+                        id -> resolveHandler(failureHandlers, ReplyFailureHandler.class, name,
+                                "reply.failure.handler", id)))
                 .build();
     }
 

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactoryImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/configuration/PublisherChannelConfigurationFactoryImpl.java
@@ -3,8 +3,6 @@ package io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration
 import java.time.Duration;
 import java.util.Optional;
 
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnector;
-import io.smallrye.reactive.messaging.providers.impl.Configs;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
@@ -12,12 +10,14 @@ import jakarta.enterprise.inject.Instance;
 import org.eclipse.microprofile.config.Config;
 import org.jspecify.annotations.NonNull;
 
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnector;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnectorOutgoingConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.CorrelationIdHandler;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.ReplyFailureHandler;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.reply.UuidCorrelationIdHandler;
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
+import io.smallrye.reactive.messaging.providers.impl.Configs;
 
 @ApplicationScoped
 public class PublisherChannelConfigurationFactoryImpl implements PublisherChannelConfigurationFactory {
@@ -68,10 +68,12 @@ public class PublisherChannelConfigurationFactoryImpl implements PublisherChanne
         final var failureHandlerId = channelConfig.getReplyFailureHandler();
         return PublisherChannelConfigurationImpl.builder()
                 .name(name)
-                .stream(channelConfig.getStream().orElseThrow(() -> new IllegalArgumentException(String.format("Missing stream for channel: %s", name))))
+                .stream(channelConfig.getStream()
+                        .orElseThrow(() -> new IllegalArgumentException(String.format("Missing stream for channel: %s", name))))
                 .retryBackoff(channelConfig.getRetryBackoff().map(Duration::ofMillis))
                 .datasource(channelConfig.getDatasource().orElse(ClientRegistry.DEFAULT_CLIENT_NAME))
-                .subject(channelConfig.getSubject().orElseThrow(() -> new IllegalArgumentException(String.format("Missing subject for channel: %s", name))))
+                .subject(channelConfig.getSubject().orElseThrow(
+                        () -> new IllegalArgumentException(String.format("Missing subject for channel: %s", name))))
                 .replySubject(channelConfig.getReplySubject())
                 .replyTimeout(Optional.of(Duration.ofMillis(channelConfig.getReplyTimeout())))
                 .replyInactiveThreshold(Optional.of(Duration.ofMillis(channelConfig.getReplyInactiveThreshold())))

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/MessageProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/MessageProcessor.java
@@ -2,6 +2,8 @@ package io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors;
 
 import org.jspecify.annotations.NonNull;
 
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ChannelConfiguration;
+
 /**
  * Represents a processor responsible for handling messages within a messaging system.
  * Implementations of this interface can define specific behavior for consuming,
@@ -11,24 +13,14 @@ import org.jspecify.annotations.NonNull;
 public interface MessageProcessor {
 
     /**
-     * Returns the name of the channel associated with the message processor.
-     * This method identifies the specific channel used by the messaging system for communication
-     * and is essential for tracking or debugging operations related to the processor.
+     * Retrieves the channel configuration associated with the message processor.
+     * This configuration provides details about the channel, including its name,
+     * associated stream, retry backoff settings, and the underlying datasource.
      *
-     * @return a non-null string representing the name of the channel.
+     * @return a non-null {@code ChannelConfiguration} object representing the channel configuration.
      */
     @NonNull
-    String channel();
-
-    /**
-     * Retrieves the name of the stream associated with the message processor.
-     * This method provides the specific identifier for the stream being utilized by the message
-     * processor, which can be used for monitoring or managing message streams in the system.
-     *
-     * @return a non-null string representing the name of the stream.
-     */
-    @NonNull
-    String stream();
+    ChannelConfiguration channelConfiguration();
 
     /**
      * Retrieves the health status of the message processor.

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/publisher/MessagePublisherProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/publisher/MessagePublisherProcessor.java
@@ -1,13 +1,13 @@
 package io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.publisher;
 
-import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.Client;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ChannelConfiguration;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ConsumerChannelConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.Health;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.MessageProcessor;
 import io.smallrye.mutiny.Multi;
@@ -15,51 +15,22 @@ import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog
 public class MessagePublisherProcessor<T> implements MessageProcessor {
-    private final String channel;
-    private final String stream;
-    private final String consumer;
+    private final ConsumerChannelConfiguration channelConfiguration;
     private final Client client;
-    private final Integer batchSize;
-    private final Duration timeout;
-
     private final AtomicReference<Health> health;
-    private final Duration retryBackoff;
-    private final Class<T> payloadType;
     private volatile boolean stopped;
 
-    public MessagePublisherProcessor(@NonNull final String channel,
-            @NonNull final String stream,
-            @NonNull final String consumer,
-            @NonNull final Integer batchSize,
-            @NonNull final Duration timeout,
-            @NonNull final Client client,
-            @NonNull final Duration retryBackoff,
-            @Nullable final Class<T> payloadType) {
-        this.channel = channel;
-        this.stream = stream;
-        this.consumer = consumer;
-        this.batchSize = batchSize;
-        this.timeout = timeout;
+    public MessagePublisherProcessor(@NonNull final ConsumerChannelConfiguration channelConfiguration,
+            @NonNull final Client client) {
+        this.channelConfiguration = channelConfiguration;
         this.client = client;
-        this.retryBackoff = retryBackoff;
-        this.payloadType = payloadType;
-
         this.health = new AtomicReference<>(Health.builder().message("Publish processor inactive").healthy(false).build());
         this.stopped = false;
     }
 
     @Override
-    public @NonNull String channel() {
-        return channel;
-    }
-
-    @Override
-    public @NonNull String stream() {
-        return stream;
-    }
-
-    public String consumer() {
-        return consumer;
+    public @NonNull ChannelConfiguration channelConfiguration() {
+        return channelConfiguration;
     }
 
     @Override
@@ -74,20 +45,25 @@ public class MessagePublisherProcessor<T> implements MessageProcessor {
 
     public Multi<Message<T>> publisher() {
         return subscribe()
-                .onItem().invoke(() -> log.debugf("Received message from channel: %s", channel()))
+                .onItem().invoke(() -> log.debugf("Received message from channel: %s", channelConfiguration.name()))
                 .onSubscription()
                 .invoke(() -> health
-                        .set(new Health(true, String.format("Publish processor healthy for channel: %s", channel()))))
+                        .set(new Health(true,
+                                String.format("Publish processor healthy for channel: %s", channelConfiguration.name()))))
                 .onFailure().invoke(failure -> {
                     log.errorf(failure, "An error occurred with message: %s", failure.getMessage());
-                    health.set(new Health(false, String.format("Publish processor unhealthy for channel: %s", channel())));
+                    health.set(new Health(false,
+                            String.format("Publish processor unhealthy for channel: %s", channelConfiguration.name())));
                 })
-                .onFailure().retry().withBackOff(retryBackoff).until(failure -> stopped);
+                .onFailure().retry().withBackOff(channelConfiguration.getRetryBackoff()).until(failure -> stopped);
 
     }
 
     private Multi<Message<T>> subscribe() {
-        return payloadType == null ? client.subscribe(stream, consumer, timeout, batchSize)
-                : client.subscribe(stream, consumer, timeout, batchSize, payloadType);
+        return channelConfiguration.<T> payloadType()
+                .map(payloadType -> client.subscribe(channelConfiguration.stream(), channelConfiguration.getConsumer(),
+                        channelConfiguration.timeout(), channelConfiguration.batchSize(), payloadType))
+                .orElseGet(() -> client.subscribe(channelConfiguration.stream(), channelConfiguration.getConsumer(),
+                        channelConfiguration.timeout(), channelConfiguration.batchSize()));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/publisher/MessagePublisherProcessorFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/publisher/MessagePublisherProcessorFactory.java
@@ -1,50 +1,25 @@
 package io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.publisher;
 
-import java.time.Duration;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.config.Config;
 import org.jspecify.annotations.NonNull;
 
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnectorIncomingConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ConsumerChannelConfigurationFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @ApplicationScoped
 public class MessagePublisherProcessorFactory {
     private final ClientRegistry clientRegistry;
+    private final ConsumerChannelConfigurationFactory channelConfigurationFactory;
 
-    public MessagePublisherProcessor<?> create(@NonNull JetStreamConnectorIncomingConfiguration configuration) {
-        final var channel = configuration.getChannel();
-        final var stream = configuration.getStream().orElseThrow(
-                () -> new IllegalArgumentException("The 'stream' attribute must be set for the channel:" + channel));
-        final var consumer = configuration.getConsumer().orElseThrow(
-                () -> new IllegalArgumentException("The 'consumer' attribute must be set for the channel:" + channel));
-        final var datasource = configuration.getDatasource().orElse(null);
-        final var batchSize = configuration.getBatchSize();
-        final var timeout = Duration.ofMillis(configuration.getTimeout());
-        final var retryBackoff = Duration.ofMillis(configuration.getRetryBackoff());
-        final var payloadType = configuration.getPayloadType().map(this::loadClass).orElse(null);
+    public MessagePublisherProcessor<?> create(@NonNull final Config configuration) {
+        final var channelConfiguration = channelConfigurationFactory.create(configuration);
         return new MessagePublisherProcessor<>(
-                channel,
-                stream,
-                consumer,
-                batchSize,
-                timeout,
-                datasource != null ? clientRegistry.lookup(datasource)
-                        : clientRegistry.lookup(ClientRegistry.DEFAULT_CLIENT_NAME),
-                retryBackoff,
-                payloadType);
+                channelConfiguration,
+                clientRegistry.lookup(channelConfiguration.datasource()));
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> Class<T> loadClass(String type) {
-        try {
-            final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            return (Class<T>) classLoader.loadClass(type);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/subscriber/MessageSubscriberProcessor.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/subscriber/MessageSubscriberProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.subscriber;
 
-import java.time.Duration;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -8,6 +7,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jspecify.annotations.NonNull;
 
 import io.quarkiverse.reactive.messaging.nats.jetstream.client.Client;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ChannelConfiguration;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.PublisherChannelConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.Health;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.MessageProcessor;
 import io.smallrye.mutiny.Multi;
@@ -17,26 +18,17 @@ import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog
 public class MessageSubscriberProcessor<T> implements MessageProcessor {
-    private final String channel;
-    private final String stream;
-    private final String subject;
-    private final Duration retryBackoff;
+    private final PublisherChannelConfiguration channelConfiguration;
 
     private final AtomicReference<Health> health;
     private final Client client;
 
     private volatile boolean stopped;
 
-    public MessageSubscriberProcessor(@NonNull final String channel,
-            @NonNull final String stream,
-            @NonNull final String subject,
-            @NonNull Client client,
-            @NonNull final Duration retryBackoff) {
-        this.channel = channel;
-        this.stream = stream;
-        this.subject = subject;
+    public MessageSubscriberProcessor(@NonNull final PublisherChannelConfiguration channelConfiguration,
+            @NonNull Client client) {
+        this.channelConfiguration = channelConfiguration;
         this.client = client;
-        this.retryBackoff = retryBackoff;
         this.health = new AtomicReference<>(new Health(true, "Subscriber processor inactive"));
         this.stopped = false;
     }
@@ -47,20 +39,18 @@ public class MessageSubscriberProcessor<T> implements MessageProcessor {
 
     private Multi<Message<T>> subscribe(Multi<Message<T>> subscription) {
         return subscription.onItem().transformToUniAndMerge(this::publish)
-                .onItem().invoke(() -> health.set(new Health(true, "Subscriber processor active for channel: " + channel())))
+                .onItem()
+                .invoke(() -> health
+                        .set(new Health(true, "Subscriber processor active for channel: " + channelConfiguration.name())))
                 .onFailure().invoke(throwable -> health.set(new Health(false,
-                        "Subscriber processor error for channel: " + channel() + " with message: " + throwable.getMessage())))
-                .onFailure().retry().withBackOff(retryBackoff).until(failure -> stopped);
+                        "Subscriber processor error for channel: " + channelConfiguration.name() + " with message: "
+                                + throwable.getMessage())))
+                .onFailure().retry().withBackOff(channelConfiguration.getRetryBackoff()).until(failure -> stopped);
     }
 
     @Override
-    public @NonNull String channel() {
-        return channel;
-    }
-
-    @Override
-    public @NonNull String stream() {
-        return stream;
+    public @NonNull ChannelConfiguration channelConfiguration() {
+        return channelConfiguration;
     }
 
     @Override
@@ -74,6 +64,6 @@ public class MessageSubscriberProcessor<T> implements MessageProcessor {
     }
 
     private Uni<Message<T>> publish(Message<T> message) {
-        return client.publish(message, stream, subject);
+        return client.publish(message, channelConfiguration.stream(), channelConfiguration.subject());
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/subscriber/MessageSubscriberProcessorFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/processors/subscriber/MessageSubscriberProcessorFactory.java
@@ -1,35 +1,25 @@
 package io.quarkiverse.reactive.messaging.nats.jetstream.connector.processors.subscriber;
 
-import java.time.Duration;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.config.Config;
 import org.jspecify.annotations.NonNull;
 
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.JetStreamConnectorOutgoingConfiguration;
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.PublisherChannelConfigurationFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @ApplicationScoped
 public class MessageSubscriberProcessorFactory {
     private final ClientRegistry clientRegistry;
+    private final PublisherChannelConfigurationFactory publisherChannelConfigurationFactory;
 
-    public <T> MessageSubscriberProcessor<T> create(@NonNull final JetStreamConnectorOutgoingConfiguration configuration) {
-        final var channel = configuration.getChannel();
-        final var stream = configuration.getStream().orElseThrow(
-                () -> new IllegalArgumentException("The 'stream' attribute must be set for the JetStream connector."));
-        final var subject = configuration.getSubject().orElseThrow(
-                () -> new IllegalArgumentException("The 'subject' attribute must be set for the JetStream connector."));
-        final var datasource = configuration.getDatasource().orElse(null);
-        final var retryBackoff = Duration.ofMillis(configuration.getRetryBackoff());
+    public <T> MessageSubscriberProcessor<T> create(@NonNull final Config configuration) {
+        final var channelConfiguration = publisherChannelConfigurationFactory.create(configuration);
         return new MessageSubscriberProcessor<>(
-                channel,
-                stream,
-                subject,
-                datasource != null ? clientRegistry.lookup(datasource)
-                        : clientRegistry.lookup(ClientRegistry.DEFAULT_CLIENT_NAME),
-                retryBackoff);
+                channelConfiguration,
+                clientRegistry.lookup(channelConfiguration.datasource()));
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/reply/RequestReplyFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/reactive/messaging/nats/jetstream/connector/reply/RequestReplyFactory.java
@@ -9,7 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.Config;
 
 import io.quarkiverse.reactive.messaging.nats.jetstream.connector.client.ClientRegistry;
-import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.ChannelConfigurationFactory;
+import io.quarkiverse.reactive.messaging.nats.jetstream.connector.configuration.PublisherChannelConfigurationFactory;
 import io.smallrye.reactive.messaging.EmitterConfiguration;
 import io.smallrye.reactive.messaging.EmitterFactory;
 import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
@@ -25,13 +25,13 @@ import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
 public class RequestReplyFactory implements EmitterFactory<RequestReplyImpl<Object, Object>> {
     private final ClientRegistry clientRegistry;
     private final Config config;
-    private final ChannelConfigurationFactory channelConfigurationFactory;
+    private final PublisherChannelConfigurationFactory channelConfigurationFactory;
 
     private final Set<RequestReplyImpl<?, ?>> emitters = ConcurrentHashMap.newKeySet();
 
     public RequestReplyFactory(final ClientRegistry clientRegistry,
             final Config config,
-            final ChannelConfigurationFactory channelConfigurationFactory) {
+            final PublisherChannelConfigurationFactory channelConfigurationFactory) {
         this.clientRegistry = clientRegistry;
         this.config = config;
         this.channelConfigurationFactory = channelConfigurationFactory;


### PR DESCRIPTION
Refactor channel configuration design: split `ChannelConfigurationFactory` into `ConsumerChannelConfigurationFactory` and `PublisherChannelConfigurationFactory`, implement factory methods, and update related classes to use the new structure.